### PR TITLE
Simplification of publish-to-pypi so it only happens manually

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,11 +4,19 @@ name: Public Python distribution to TestPyPI
 
 # Controls when the workflow will run
 on:
-  pull_request:
-    branches: [ GitActions ]
-  push:
-    branches: [ GitActions ]
   workflow_dispatch:
+    inputs:
+      pypi:
+        description: 'Release to PyPI'
+        required: false
+        default: false
+        type: boolean
+
+      test_pypi:
+        description: 'Release to Test PyPI'
+        required: false
+        default: true
+        type: boolean
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -104,7 +112,7 @@ jobs:
           find dist -type f | grep -v manylinux | xargs sudo rm
 
       - name: Publish distribution to Test PyPI
-        if: true
+        if: ${{ inputs.test_pypi }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -113,7 +121,7 @@ jobs:
           python -m twine upload --verbose --skip-existing dist/*
 
       - name: Publish distribution to PyPI
-        if: true
+        if: ${{ inputs.pypi }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -22,7 +22,6 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build_swig_tools:
-    if: github.repository == 'fyellin/pds-cspyce'
     runs-on: ubuntu-latest
 
     steps:
@@ -48,7 +47,6 @@ jobs:
             cspyce/cspyce0.py
 
   build-distribution:
-    # if: github.repository == 'fyellin/pds-cspyce'
     runs-on: ${{ matrix.os }}
     needs: [build_swig_tools]
 


### PR DESCRIPTION
Change publish-to-pypi.yml so it only happens manually.  This also allows there to be variables controlling whether the push is to TestPyPI or to PyPI, without having to modify the file.

Updates to documentation will be coming soon.