### PR TITLE
Better Release Process

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -10,13 +10,13 @@ on:
       prerelease_version:
         description: 'Prerelease Version'
         required: true
-        default: ''
+        default: 'release'
         type: string
 
       test_pypi:
         description: 'Release to Test PyPI'
         required: true
-        default: true
+        default: false
         type: boolean
 
       pypi:
@@ -25,134 +25,112 @@ on:
         default: false
         type: boolean
 
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build-macos-windows-source:
+  build_python3_wheels:
+    name: Build Python 3 wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-
     strategy:
       matrix:
-        include:
-          # MacOS builds
-          - {os: macos-latest, python: 2.7, dist: bdist_wheel}
-          - {os: macos-latest, python: 3.8, dist: bdist_wheel}
-          - {os: macos-latest, python: 3.9, dist: bdist_wheel}
-          - {os: macos-latest, python: '3.10', dist: bdist_wheel}
-#          # Windows builds
-          - {os: windows-latest, python: 3.8, dist: bdist_wheel}
-          - {os: windows-latest, python: 3.9, dist: bdist_wheel}
-          - {os: windows-latest, python: '3.10', dist: bdist_wheel}
-#          # Source build
-          - {os: ubuntu-latest, python: 3.8, dist: sdist }
+        os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Setup Windows compiler
-        if: ${{ matrix.os == 'windows-latest' }}
-        uses: ilammy/msvc-dev-cmd@v1.4.1
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.11.1
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
+          CIBW_BEFORE_BUILD: 'pip3 install numpy setuptools && python3 setup.py generate'
+          CIBW_ENVIRONMENT: PRERELEASE_VERSION=${{ inputs.prerelease_version }}
+          CIBW_SKIP: 'pp* *musllinux* *cp27mu*'
+          CIBW_ARCHS: 'auto64'
+          CIBW_ARCHS_MACOS: 'x86_64 arm64'
 
-      - name: Set up Build Python
-        if: matrix.python == 2.7
-        uses: actions/setup-python@v2
+      - uses: actions/upload-artifact@v3
         with:
-          python-version: 3.8
+          path: ./wheelhouse/*.whl
 
-      - name: Set up Requested Python
-        uses: actions/setup-python@v2
+  build_python2_wheels:
+    name: Build Python 2.7 wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: 
+        # windows-2019 doesn't seem to work for 2.7
+        os: [ ubuntu-latest, macOS-latest ]
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python || 3.8 }}
+          python-version: '3.9'
 
-      - name: Initialize Python
+      - name: Pre-build stuff
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine numpy
+          pip install numpy setuptools
+          python setup.py generate
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v1.12.0
         env:
-          PRERELEASE_VERSION: ${{ inputs.prerelease_version }}
+          CIBW_BUILD: '*cp27*'
+          CIBW_SKIP: '*musllinux* *pp27* *cp27mu*'
+          CIBW_ENVIRONMENT: PRERELEASE_VERSION=${{ inputs.prerelease_version }}
+          CIBW_ARCHS: 'auto64'
+          CIBW_ARCHS_MACOS: 'x86_64 arm64'
 
-      - name: Generate swig files
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install setuptools wheel twine numpy
-          echo $PRERELEASE_VERSION > prerelease_version.txt
-          python3 setup.py generate
-        env:
-          PRERELEASE_VERSION: ${{ inputs.prerelease_version }}
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
 
-      - name: Build distribution
-        run: |
-          python setup.py ${{ matrix.dist }}
-
-      - name: Publish distribution to Test PyPI
-        if: inputs.test_pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-        run: |
-          python -m twine upload --verbose --skip-existing dist/*
-
-      - name: Publish distribution to PyPI2
-        if: inputs.pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
-        run:
-          python -m twine upload --verbose --skip-existing dist/*
-
-  build-linux:
+  build_sdist:
+    name: Build source distribution
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        include:
-           - {docker-python: cp38-cp38}
-           - {docker-python: cp39-cp39}
-           - {docker-python: cp310-cp310}
-      fail-fast: false
-
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.9'
 
-      - name: Python Setup
+      - name: Build sdist
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install setuptools wheel twine numpy
-          echo "prerelease version" $PRERELEASE_VERSION
-          echo $PRERELEASE_VERSION > prerelease_version.txt
+          printenv
+          sudo apt install swig
+          pip install numpy setuptools wheel
+          python3 setup.py generate
+          python3 setup.py sdist
         env:
           PRERELEASE_VERSION: ${{ inputs.prerelease_version }}
 
-      - name: Python Build Linux
-        uses: RalfG/python-wheels-manylinux-build@v0.5.0-manylinux2014_x86_64
+      - uses: actions/upload-artifact@v3
         with:
-          python-versions: ${{ matrix.docker-python }}
-          build-requirements: 'numpy'
-          system-packages: 'swig'
-          pre-build-command: '/opt/python/cp38-cp38/bin/python setup.py generate'
+          path: dist/*.tar.gz
 
-      - name: Publish distribution to Test PyPI
+
+  upload_pypi:
+    needs: [build_python3_wheels, build_python2_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact   # prevents extra directory
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
         if: inputs.test_pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
-        run: |
-          python -m twine upload --verbose --skip-existing dist/*manylinux*.whl
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+          verify_metadata: false
 
-      - name: Publish distribution to PyPI2
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
         if: inputs.pypi
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
-        run:
-          python -m twine upload --verbose --skip-existing dist/*manylinux*.whl
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          verify_metadata: false
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ wheelhouse/
 cspyce/cspyce0.py
 cspyce/cspyce0_info.py
 swig/vectorize.i
-prerelease_version.txt

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # We prefer setuptools, but will use distutils if setuptools isn't available
 import os
 from glob import glob
+import os
 import subprocess
 import sys
 
@@ -115,15 +116,10 @@ class MyBuildExt(build_ext):
 
 
 def do_setup():
-    try:
-        directory = os.path.dirname(os.path.abspath(__file__))
-        prerelease_version_file = os.path.join(directory, "prerelease_version.txt")
-        with open(prerelease_version_file, "r")  as f:
-            prerelease_version = f.read().strip()
-            if prerelease_version == 'release':
-                prerelease_version = ''
-    except IOError:
+    prerelease_version = os.getenv('PRERELEASE_VERSION', '')
+    if prerelease_version == 'release':
         prerelease_version = ''
+
     setup(
         name='cspyce',
         version='2.0.5' + prerelease_version,


### PR DESCRIPTION
Use cibuildwheel for building wheels, which is better maintained and documented.
Change PRERELEASE_VERSION to be an environment variable rather than a file, since cibuildwheel supports setting environment variables.
Build more wheels: MacOS ARM, Linux 2.7.  