### PR TITLE
Minor cleanup, bug fixes, and documentation fixes

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,4 +1,5 @@
-# This is a basic workflow to help you get started with Actions
+# This workflow compiles CSPICE for many architectures and publishes a branch
+# to Test-PyPi or PyPi
 
 name: Publish to PyPI
 run-name: Publish ${{ inputs.prelease_version }} by ${{ github.actor }}
@@ -38,7 +39,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.11.2
+        uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_PROJECT_REQUIRES_PYTHON: '>=3.8'
           CIBW_BEFORE_BUILD: 'pip3 install numpy setuptools && python3 setup.py generate'
@@ -55,7 +56,7 @@ jobs:
     name: Build Python 2.7 wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix: 
+      matrix:
         # windows-2019 doesn't seem to work for 2.7
         os: [ ubuntu-latest, macOS-latest ]
       fail-fast: false
@@ -133,4 +134,3 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
           verify_metadata: false
-

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,27 +1,186 @@
 Academic Free License ("AFL") v. 3.0
 
-This Academic Free License (the "License") applies to any original work of authorship (the "Original Work") whose owner (the "Licensor") has placed the following licensing notice adjacent to the copyright notice for the Original Work:
+This Academic Free License (the "License") applies to any original
+work of authorship (the "Original Work") whose owner (the "Licensor")
+has placed the following licensing notice adjacent to the copyright
+notice for the Original Work:
 
 Licensed under the Academic Free License version 3.0
 
-1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free, non-exclusive, sublicensable license, for the duration of the copyright, to do the following:
-a) to reproduce the Original Work in copies, either alone or as part of a collective work;
-b) to translate, adapt, alter, transform, modify, or arrange the Original Work, thereby creating derivative works ("Derivative Works") based upon the Original Work;
-c) to distribute or communicate copies of the Original Work and Derivative Works to the public, under any license of your choice that does not contradict the terms and conditions, including Licensor's reserved rights and remedies, in this Academic Free License;
+1) Grant of Copyright License. Licensor grants You a worldwide,
+royalty-free, non-exclusive, sublicensable license, for the duration
+of the copyright, to do the following:
+
+a) to reproduce the Original Work in copies, either alone or as part
+of a collective work;
+
+b) to translate, adapt, alter, transform, modify, or arrange the
+Original Work, thereby creating derivative works ("Derivative Works")
+based upon the Original Work;
+
+c) to distribute or communicate copies of the Original Work and
+Derivative Works to the public, under any license of your choice that
+does not contradict the terms and conditions, including Licensor's
+reserved rights and remedies, in this Academic Free License;
+
 d) to perform the Original Work publicly; and
+
 e) to display the Original Work publicly.
-2) Grant of Patent License. Licensor grants You a worldwide, royalty-free, non-exclusive, sublicensable license, under patent claims owned or controlled by the Licensor that are embodied in the Original Work as furnished by the Licensor, for the duration of the patents, to make, use, sell, offer for sale, have made, and import the Original Work and Derivative Works.
-3) Grant of Source Code License. The term "Source Code" means the preferred form of the Original Work for making modifications to it and all available documentation describing how to modify the Original Work. Licensor agrees to provide a machine-readable copy of the Source Code of the Original Work along with each copy of the Original Work that Licensor distributes. Licensor reserves the right to satisfy this obligation by placing a machine-readable copy of the Source Code in an information repository reasonably calculated to permit inexpensive and convenient access by You for as long as Licensor continues to distribute the Original Work.
-4) Exclusions From License Grant. Neither the names of Licensor, nor the names of any contributors to the Original Work, nor any of their trademarks or service marks, may be used to endorse or promote products derived from this Original Work without express prior permission of the Licensor. Except as expressly stated herein, nothing in this License grants any license to Licensor's trademarks, copyrights, patents, trade secrets or any other intellectual property. No patent license is granted to make, use, sell, offer for sale, have made, or import embodiments of any patent claims other than the licensed claims defined in Section 2. No license is granted to the trademarks of Licensor even if such marks are included in the Original Work. Nothing in this License shall be interpreted to prohibit Licensor from licensing under terms different from this License any Original Work that Licensor otherwise would have a right to license.
-5) External Deployment. The term "External Deployment" means the use, distribution, or communication of the Original Work or Derivative Works in any way such that the Original Work or Derivative Works may be used by anyone other than You, whether those works are distributed or communicated to those persons or made available as an application intended for use over a network. As an express condition for the grants of license hereunder, You must treat any External Deployment by You of the Original Work or a Derivative Work as a distribution under section 1(c).
-6) Attribution Rights. You must retain, in the Source Code of any Derivative Works that You create, all copyright, patent, or trademark notices from the Source Code of the Original Work, as well as any notices of licensing and any descriptive text identified therein as an "Attribution Notice." You must cause the Source Code for any Derivative Works that You create to carry a prominent Attribution Notice reasonably calculated to inform recipients that You have modified the Original Work.
-7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that the copyright in and to the Original Work and the patent rights granted herein by Licensor are owned by the Licensor or are sublicensed to You under the terms of this License with the permission of the contributor(s) of those copyrights and patent rights. Except as expressly stated in the immediately preceding sentence, the Original Work is provided under this License on an "AS IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without limitation, the warranties of non-infringement, merchantability or fitness for a particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this License. No license to the Original Work is granted by this License except under this disclaimer.
-8) Limitation of Liability. Under no circumstances and under no legal theory, whether in tort (including negligence), contract, or otherwise, shall the Licensor be liable to anyone for any indirect, special, incidental, or consequential damages of any character arising as a result of this License or the use of the Original Work including, without limitation, damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses. This limitation of liability shall not apply to the extent applicable law prohibits such limitation.
-9) Acceptance and Termination. If, at any time, You expressly assented to this License, that assent indicates your clear and irrevocable acceptance of this License and all of its terms and conditions. If You distribute or communicate copies of the Original Work or a Derivative Work, You must make a reasonable effort under the circumstances to obtain the express assent of recipients to the terms of this License. This License conditions your rights to undertake the activities listed in Section 1, including your right to create Derivative Works based upon the Original Work, and doing so without honoring these terms and conditions is prohibited by copyright law and international treaty. Nothing in this License is intended to affect copyright exceptions and limitations (including "fair use" or "fair dealing"). This License shall terminate immediately and You may no longer exercise any of the rights granted to You by this License upon your failure to honor the conditions in Section 1(c).
-10) Termination for Patent Action. This License shall terminate automatically and You may no longer exercise any of the rights granted to You by this License as of the date You commence an action, including a cross-claim or counterclaim, against Licensor or any licensee alleging that the Original Work infringes a patent. This termination provision shall not apply for an action alleging patent infringement by combinations of the Original Work with other software or hardware.
-11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this License may be brought only in the courts of a jurisdiction wherein the Licensor resides or in which Licensor conducts its primary business, and under the laws of that jurisdiction excluding its conflict-of-law provisions. The application of the United Nations Convention on Contracts for the International Sale of Goods is expressly excluded. Any use of the Original Work outside the scope of this License or after its termination shall be subject to the requirements and penalties of copyright or patent law in the appropriate jurisdiction. This section shall survive the termination of this License.
-12) Attorneys' Fees. In any action to enforce the terms of this License or seeking damages relating thereto, the prevailing party shall be entitled to recover its costs and expenses, including, without limitation, reasonable attorneys' fees and costs incurred in connection with such action, including any appeal of such action. This section shall survive the termination of this License.
-13) Miscellaneous. If any provision of this License is held to be unenforceable, such provision shall be reformed only to the extent necessary to make it enforceable.
-14) Definition of "You" in This License. "You" throughout this License, whether in upper or lower case, means an individual or a legal entity exercising rights under, and complying with all of the terms of, this License. For legal entities, "You" includes any entity that controls, is controlled by, or is under common control with you. For purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
-15) Right to Use. You may use the Original Work in all ways not otherwise restricted or conditioned by this License or by law, and Licensor promises not to interfere with or be responsible for such uses by You.
-16) Modification of This License. This License is Copyright © 2005 Lawrence Rosen. Permission is granted to copy, distribute, or communicate this License without modification. Nothing in this License permits You to modify this License as applied to the Original Work or to Derivative Works. However, You may modify the text of this License and copy, distribute or communicate your modified version (the "Modified License") and apply it to other original works of authorship subject to the following conditions: (i) You may not indicate in any way that your Modified License is the "Academic Free License" or "AFL" and you may not use those names in the name of your Modified License; (ii) You must replace the notice specified in the first paragraph above with the notice "Licensed under <insert your license name here>" or with a notice of your own that is not confusingly similar to the notice in this License; and (iii) You may not claim that your original works are open source software unless your Modified License has been approved by Open Source Initiative (OSI) and You comply with its license review and certification process.
+
+2) Grant of Patent License. Licensor grants You a worldwide,
+royalty-free, non-exclusive, sublicensable license, under patent
+claims owned or controlled by the Licensor that are embodied in the
+Original Work as furnished by the Licensor, for the duration of the
+patents, to make, use, sell, offer for sale, have made, and import the
+Original Work and Derivative Works.
+
+3) Grant of Source Code License. The term "Source Code" means the
+preferred form of the Original Work for making modifications to it and
+all available documentation describing how to modify the Original
+Work. Licensor agrees to provide a machine-readable copy of the Source
+Code of the Original Work along with each copy of the Original Work
+that Licensor distributes. Licensor reserves the right to satisfy this
+obligation by placing a machine-readable copy of the Source Code in an
+information repository reasonably calculated to permit inexpensive and
+convenient access by You for as long as Licensor continues to
+distribute the Original Work.
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor
+the names of any contributors to the Original Work, nor any of their
+trademarks or service marks, may be used to endorse or promote
+products derived from this Original Work without express prior
+permission of the Licensor. Except as expressly stated herein, nothing
+in this License grants any license to Licensor's trademarks,
+copyrights, patents, trade secrets or any other intellectual
+property. No patent license is granted to make, use, sell, offer for
+sale, have made, or import embodiments of any patent claims other than
+the licensed claims defined in Section 2. No license is granted to the
+trademarks of Licensor even if such marks are included in the Original
+Work. Nothing in this License shall be interpreted to prohibit
+Licensor from licensing under terms different from this License any
+Original Work that Licensor otherwise would have a right to license.
+
+5) External Deployment. The term "External Deployment" means the use,
+distribution, or communication of the Original Work or Derivative
+Works in any way such that the Original Work or Derivative Works may
+be used by anyone other than You, whether those works are distributed
+or communicated to those persons or made available as an application
+intended for use over a network. As an express condition for the
+grants of license hereunder, You must treat any External Deployment by
+You of the Original Work or a Derivative Work as a distribution under
+section 1(c).
+
+6) Attribution Rights. You must retain, in the Source Code of any
+Derivative Works that You create, all copyright, patent, or trademark
+notices from the Source Code of the Original Work, as well as any
+notices of licensing and any descriptive text identified therein as an
+"Attribution Notice." You must cause the Source Code for any
+Derivative Works that You create to carry a prominent Attribution
+Notice reasonably calculated to inform recipients that You have
+modified the Original Work.
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor
+warrants that the copyright in and to the Original Work and the patent
+rights granted herein by Licensor are owned by the Licensor or are
+sublicensed to You under the terms of this License with the permission
+of the contributor(s) of those copyrights and patent rights. Except as
+expressly stated in the immediately preceding sentence, the Original
+Work is provided under this License on an "AS IS" BASIS and WITHOUT
+WARRANTY, either express or implied, including, without limitation,
+the warranties of non-infringement, merchantability or fitness for a
+particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL
+WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential
+part of this License. No license to the Original Work is granted by
+this License except under this disclaimer.
+
+8) Limitation of Liability. Under no circumstances and under no legal
+theory, whether in tort (including negligence), contract, or
+otherwise, shall the Licensor be liable to anyone for any indirect,
+special, incidental, or consequential damages of any character arising
+as a result of this License or the use of the Original Work including,
+without limitation, damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial
+damages or losses. This limitation of liability shall not apply to the
+extent applicable law prohibits such limitation.
+
+9) Acceptance and Termination. If, at any time, You expressly assented
+to this License, that assent indicates your clear and irrevocable
+acceptance of this License and all of its terms and conditions. If You
+distribute or communicate copies of the Original Work or a Derivative
+Work, You must make a reasonable effort under the circumstances to
+obtain the express assent of recipients to the terms of this
+License. This License conditions your rights to undertake the
+activities listed in Section 1, including your right to create
+Derivative Works based upon the Original Work, and doing so without
+honoring these terms and conditions is prohibited by copyright law and
+international treaty. Nothing in this License is intended to affect
+copyright exceptions and limitations (including "fair use" or "fair
+dealing"). This License shall terminate immediately and You may no
+longer exercise any of the rights granted to You by this License upon
+your failure to honor the conditions in Section 1(c).
+
+10) Termination for Patent Action. This License shall terminate
+automatically and You may no longer exercise any of the rights granted
+to You by this License as of the date You commence an action,
+including a cross-claim or counterclaim, against Licensor or any
+licensee alleging that the Original Work infringes a patent. This
+termination provision shall not apply for an action alleging patent
+infringement by combinations of the Original Work with other software
+or hardware.
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating
+to this License may be brought only in the courts of a jurisdiction
+wherein the Licensor resides or in which Licensor conducts its primary
+business, and under the laws of that jurisdiction excluding its
+conflict-of-law provisions. The application of the United Nations
+Convention on Contracts for the International Sale of Goods is
+expressly excluded. Any use of the Original Work outside the scope of
+this License or after its termination shall be subject to the
+requirements and penalties of copyright or patent law in the
+appropriate jurisdiction. This section shall survive the termination
+of this License.
+
+12) Attorneys' Fees. In any action to enforce the terms of this
+License or seeking damages relating thereto, the prevailing party
+shall be entitled to recover its costs and expenses, including,
+without limitation, reasonable attorneys' fees and costs incurred in
+connection with such action, including any appeal of such action. This
+section shall survive the termination of this License.
+
+13) Miscellaneous. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable.
+
+14) Definition of "You" in This License. "You" throughout this
+License, whether in upper or lower case, means an individual or a
+legal entity exercising rights under, and complying with all of the
+terms of, this License. For legal entities, "You" includes any entity
+that controls, is controlled by, or is under common control with
+you. For purposes of this definition, "control" means (i) the power,
+direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
+
+15) Right to Use. You may use the Original Work in all ways not
+otherwise restricted or conditioned by this License or by law, and
+Licensor promises not to interfere with or be responsible for such
+uses by You.
+
+16) Modification of This License. This License is Copyright © 2005
+Lawrence Rosen. Permission is granted to copy, distribute, or
+communicate this License without modification. Nothing in this License
+permits You to modify this License as applied to the Original Work or
+to Derivative Works. However, You may modify the text of this License
+and copy, distribute or communicate your modified version (the
+"Modified License") and apply it to other original works of authorship
+subject to the following conditions: (i) You may not indicate in any
+way that your Modified License is the "Academic Free License" or "AFL"
+and you may not use those names in the name of your Modified License;
+(ii) You must replace the notice specified in the first paragraph
+above with the notice "Licensed under <insert your license name here>"
+or with a notice of your own that is not confusingly similar to the
+notice in this License; and (iii) You may not claim that your original
+works are open source software unless your Modified License has been
+approved by Open Source Initiative (OSI) and You comply with its
+license review and certification process.

--- a/README-developers.md
+++ b/README-developers.md
@@ -3,7 +3,7 @@ March 2022
 
 Frank Yellin.
 
-This guide is intended for those who have downloaded the 
+This guide is intended for those who have downloaded the
 [GitHub source code](https://github.com/SETI/pds-cspyce/) and are modifying
 or extending the `cspyce` toolkit.
 You do not need to read this if you are installing an existing `PyPI`
@@ -27,13 +27,13 @@ runtime. If you have multiple versions of Python installed on your computer,
 you may need to be running `python2` and `python3`, or `python3.8` and
 `python3.9`.
 
-In general, our `.py` and `.c` sources should work across all implementations of 
+In general, our `.py` and `.c` sources should work across all implementations of
 Python beyond 2.7. However, there is no expectation of binary compatibility between
 multiple versions.
 
-### Step1: 
+### Step1:
 
-You must have swig and a newer version (≥ 3.8) of Python3 running on 
+You must have swig and a newer version (≥ 3.8) of Python3 running on
 your computer for the first step:
 ```shell
 python3 setup.py generate
@@ -49,11 +49,11 @@ The downloaded sources will appear in two directories:
 where `<os>` and `<arch>` indicate your machine's operating system and architecture.
 
 ### Step 2
-You compile the C implementation of the Spice library by running:
+You compile the C implementation of the SPICE library by running:
 ```shell
 python setup.py build_clib
 ```
-This may execute somewhat slowly because it is compiling several thousand files. 
+This may execute somewhat slowly because it is compiling several thousand files.
 You should only need to do this once.
 
 ### Step 3
@@ -62,12 +62,13 @@ You then build `cspyce` by running the command
 python setup.py build_ext --inplace
 ```
 It is particularly important that you execute this command using the same
-version of Python that you are planning to use for running cspyce.
+version of Python that you are planning to use for running `cspyce`.
 Python does not guarantee binary compatibility between Python versions.
 
 If you modify any of the templates, you will need to re-run the "generate"
-command above (using Python3) and the "build_ext" command.
-The Python `setuptools` is not yet smart enough to understand dependencies.
+command above (using python3) and the "build_ext" command.
+The Python `setuptools` module is not yet smart enough to understand
+dependencies.
 
 ### Step 4
 Once you have built `cspyce`, you should confirm that it works.
@@ -81,8 +82,8 @@ If you have previously installed cspyce via pip, you should also look at the val
 ```shell
 > cspyce.__file__
 ```
-to confirm that you area loading at the cspyce you have just built rather than the
-pip-installed cspyce.
+to confirm that you area looking at the `cspyce` you have just built rather than
+the pip-installed `cspyce`.
 The value returned should be `"<your current directory>/cspyce/__init__.py"`
 
 ## CREATING A DISTRIBUTION
@@ -105,16 +106,16 @@ This file can be uploaded to PyPI and then downloaded by any version of
 Python on any operating system. The `.tar.gz` contains all the sources needed
 to compile and run `cspyce`.
 It includes the necessary pieces of the `cspice/` source tree as well as an
-already generated `cspyce0_wrap.c` file so that they do not need to install 
-`swig.`
+already generated `cspyce0_wrap.c` file so that the end user does not need to
+install `swig.`
 
-Although building a source distribution is very quick, 
-the installing process (`pip install cspyce`) may take a few minutes because 
+Although building a source distribution is very quick,
+the installing process (`pip install cspyce`) may take a few minutes because
 2000 files from the CSPICE library are being compiled.
 
 ### Wheel distributions
 
-A second type of distribution is the "wheel". 
+A second type of distribution is the "wheel".
 ```shell
 python setup.py bdist_wheel
 ```
@@ -149,16 +150,14 @@ even if you have deleted a version.
 
 By default, the version is that given in `setup.py`.
 You add a suffix to this command by including `egginfo -b <tag>` where the tag
-is either one of the letters a (for alpha), b (for beta), or c (for release
-candidate). The letter can optionally be followed by a number. 
+is either one of the letters a (for alpha), b (for beta), or rc (for release
+candidate). The letter can optionally be followed by a number.
 
 Hence a series of releases can be created by
-```
-python setup.py egg_info -b a1 sdist bdist_wheel
-```
-```
-python setup.py egg_info -b a2 sdist bdist_wheel
-```
+
+      python setup.py egg_info -b a1 sdist bdist_wheel
+      python setup.py egg_info -b a2 sdist bdist_wheel
+
 etc. without causing a naming conflict at the distribution sites.
 
 ## UPLOADING A DISTRIBUTION TO PyPI
@@ -166,23 +165,24 @@ etc. without causing a naming conflict at the distribution sites.
 > These instructions do not work for wheels built on Linux. PyPI and TestPyPI have
 > special rules for Linux to ensure that Linux releases can work on all the various
 > versions of Linux.
-> 
-> You can continue to use Linux wheels on your own computer. 
+>
+> You can continue to use Linux wheels on your own computer.
 > Releases must be built on GitHub.
 > See the next section.
 
 
 Although `setup.py` supports the command `upload`, this usage has been deprecated.
 You should instead use `twine`.
-You should already have installed `twine` above.
+You should have already installed `twine` above.
 
-The distributions you created above will be in a subdirectory `dist/`. 
+The distributions you created above will be in a subdirectory `dist/`.
 
 You upload a distribution to test.pypi by running:
 ```shell
 twine upload --repository testpypi <file1>, <file2>, <file3>, ...
 ```
-(`--repository` can be shorted to `-r`)
+(`--repository` can be shortened to `-r`)
+
 You upload a distribution to the main PyPI repository by simply running
 ```shell
 twine upload <file1>, <file2>, ...
@@ -192,22 +192,22 @@ The name and password for test.pypi are separate from the name and password for 
 main PyPI repository.
 
 You can create the following file at `~/.pypirc`
-```
-[distutils]
-index-servers =
-    pypi
-    testpypi
 
-[pypi]
-repository = https://upload.pypi.org/legacy/
-username = your_pypi_username
-password = your_pypi_password
+      [distutils]
+      index-servers =
+         pypi
+         testpypi
 
-[testpypi]
-repository = https://test.pypi.org/legacy/
-username = your_test_pypi_usename
-password = your_test_pypi_password
-```
+      [pypi]
+      repository = https://upload.pypi.org/legacy/
+      username = your_pypi_username
+      password = your_pypi_password
+
+      [testpypi]
+      repository = https://test.pypi.org/legacy/
+      username = your_test_pypi_usename
+      password = your_test_pypi_password
+
 Be sure to make this file publicly unreadable since it contains your passwords.
 
 ## USING GitHub TO CREATE A DISTRIBUTION
@@ -221,11 +221,8 @@ and at [PyPi](https://pypi.org/)
 
 #### Get Permission to access cspyce
 
-Separate permission needs to be provided for both PyPI and Test PyPI.
-For now, only Frank Yellin and Rob French can do this.
-They should visit these two URLs and add you as a collaborator.
-- https://pypi.org/manage/project/cspyce/collaboration/
-- https://test.pypi.org/manage/project/cspyce/collaboration
+If necessary, contact the owner of the destination package on PyPi to be added
+as a collaborator.
 
 #### Create tokens for PyPI and Test PyPI
 
@@ -235,7 +232,7 @@ Visit each of the following two URLs in turn:
   - https://pypi.org/manage/account/token/
   - https://test.pypi.org/manage/account/token
 
-For each of the URLs, 
+For each of the URLs,
 1. Fill in the two fields. The token name can be whatever you want.
 The scope should be `Project: cspyce`
 2. Click "Add token"
@@ -252,20 +249,20 @@ password.
 
 1. Log into your GitHub repository for pds-cspyce
 2. Click "settings", then "secrets" on the left-hand menu, then "actions".
-3. Use the "New Repository Secret" button to add two secrets named `PYPI_API_TOKEN` 
-and `TEST_PYPI_API_TOKEN`. 
+3. Use the "New Repository Secret" button to add two secrets named `PYPI_API_TOKEN`
+and `TEST_PYPI_API_TOKEN`.
 The value of each of these two secrets should be the appropriate API token
 generated above.
 
 #### (Optional) Install `gh`, the GitHub command-line interface
 
-The GitHub commands to run the actions can be executed either using a 
+The GitHub commands to run the actions can be executed either using a
 command-line interface (CLI), or by visiting the GitHub website.
 
-To use the CLI, visit https://github.com/cli/cli for information on 
+To use the CLI, visit https://github.com/cli/cli for information on
 installing `gh` on your machine.
 
-After installation, you must run the command `gh auth login` and follow the instructions to 
+After installation, you must run the command `gh auth login` and follow the instructions to
 authorize `gh` to access your account.
 
 ### Creating a new distribution
@@ -276,9 +273,9 @@ When you are planning on creating a pull request that requires a new distributio
 sure that you update the version number in `setup.py`.
 The version number appears in the `do_setup()` function at the very end of the file.
 
-> Note to Rob: When approving a request that will require making a new distribution, 
+> Note to Rob: When approving a request that will require making a new distribution,
 > ensure that the version number is updated.
-> 
+>
 #### Step 2: Ensure you have a local branch
 
 Make sure you have a local branch that points to the commit where you want to create the distribution.
@@ -288,12 +285,12 @@ If you are not the creator, then do a pull of the development branch from the Gi
 
 #### Step 3: Understand version numbers
 
-You should first try releasing alpha and beta versions of your code to Test PyPI 
+You should first try releasing alpha and beta versions of your code to Test PyPI
 before attempting to release to the public. Each release needs a separate version number.
 
 You can find the version number in `setup.py`.
 
-If the version number is, for example, `2.0.5`, we would want the first release sent to 
+If the version number is, for example, `2.0.5`, we would want the first release sent to
 Test PyPI to be `2.0.5a1` indicating that this is the alpha-1 version of 2.0.5.
 This would be followed by `2.0.5a2`, `2.0.5a3`, etc.
 
@@ -301,25 +298,15 @@ As we got closer to a final version, we would change `a` to `b`, and restart the
 from 1, indicating we are at beta.  Then we would change the `b` to `rc`, indicating that
 this is a release candidate (again, restarting the numbering from 1).
 
-We call the suffix you append to the `version` listed in `setup.py` 
+We call the suffix you append to the `version` listed in `setup.py`
 as the "Prerelease Version".
 
 #### Step 4: Build a Test PyPI release
 
-By default, we generate four MacOS builds (2.7, 3.8, 3.9, 3.10), three Windows
-builds (3.8, 3.9, 3.10), three Linux builds (3.8, 3.9, 3.10), and a source build.
-Feel free to comment out the obvious lines if needed.
-
-> When new Python images become available, modify the above list in the `master`
-> version of this file.
-
-> Note that 3.10 needs to be quoted because yml thinks 3.10 is just 3.1.
-> When 3.11 is released, this shouldn't be a problem
-
 Ensure that your development branch is committed and pushed to your GitHub repository,
 including setting the appropriate version number in `setup.py`.
 
-If using web interface, 
+If using the GitHub web interface,
 
    1. Log into your GitHub account.
    2. Select your repository.
@@ -338,9 +325,10 @@ If using web interface,
 
 If using the CLI, run the following command:
 
-```
+```shell
 gh workflow run publish-to-pypi.yml --ref <branch> -f prerelease_version=<xx> -f test_pypi=true -f pypi=false
 ```
+
 where `<branch>` is the name of your development branch and `<xx>` is the prerelease version
 as described above.
 
@@ -351,7 +339,7 @@ the run.
 
 You *may* see the several error messages that Python 2.7 isn't supported;
 these can be ignored.
-If you see any other error messages, please investigate. 
+If you see any other error messages, please investigate.
 Otherwise, your build has been released to TestPyPI.
 
 #### Step 5: Test and retry
@@ -360,23 +348,22 @@ Test the results.
 
 You should generally create a new virtual environment for testing a prerelease cspyce.
 
-```
-$ python -m venv tester
-$ source tester/bin/activate
-$ pip install numpy
-$ pip install -i https://test.pypi.org/simple/ cspyce==2.0.5a1
-$ python
-> import cspyce
-```
+      $ python -m venv tester
+      $ source tester/bin/activate
+      $ pip install numpy
+      $ pip install -i https://test.pypi.org/simple/ cspyce==2.0.5a1
+      $ python
+      > import cspyce
+
 Of course, replace `2.0.5a1` with your current pre-release version number.
 
 > Note: For release images on PyPI, `numpy` is installed automatically when installing
 > `cspyce`.  This does not work when installing from Test PyPI.
-> 
+>
 If there are any problems, fix them.
 
 Repeat Steps 4 and 5 as many times as necessary.
-Remember that you need to update the value of the prerelease version  in step 6ii
+Remember that you need to update the value of the prerelease version  in step 6.2
 each time you create a new release.
 
 #### Step 6: Publish to PyPI
@@ -393,12 +380,12 @@ If using the CLI, run the following command:
 gh workflow run publish-to-pypi.yml --ref <branch> -f prerelease_version=release -f test_pypi=true -f pypi=true
 ```
 where `<branch>` is the name of your development branch and `<xx>` is the prerelease suffix
-you would have entered in step 6ii above.
+you would have entered in step 6.2 above.
 
 
 > Note: I am trying to figure out how to get rid of "Release to PyPI" and make
 > it depend on whether the prerelease version is "release" or not.
-> No one's answered my question on stackoverflow yet. 
+> No one's answered my question on stackoverflow yet.
 
 > Note: It seems the "Prerelease Version" field cannot be empty.
 > I would have liked

--- a/README.md
+++ b/README.md
@@ -5,17 +5,19 @@ March, 2022
 
 Mark Showalter, PDS Ring-Moon Systems Node, SETI Institute
 
-Spyce is a Python module that provides an interface to the CSPICE library. It
-implements the most widely-used functions of CSPICE in a Python-like way. It
-also supports numerous enhancements, including support for Python exceptions,
-array inputs, and aliases.
+`cspyce` is a Python module that provides an interface to the C-language CSPICE
+library produced by the Navigation and Ancillary Information Facility
+([NAIF](https://naif.jpl.nasa.gov/naif/)) of NASA's Planetary Data System (PDS).
+It implements the most widely-used functions of CSPICE in a Python-like way,
+while also supporting numerous enhancements, including support for Python
+exceptions, array inputs, and aliases.
 
 If you are looking for information on running or distributing this code from
-the github sources, look at the file `README-developers.md` in this directory.
+the GitHub sources, look at the file `README-developers.md` in this directory.
 
 ## PYTHONIZATION
 
-This module has been designed to replicate the core features of CSPICE for
+`cspyce` has been designed to replicate the core features of CSPICE for
 users who wish to translate a program that already exists. Function names in
 `cspyce` match their CSPICE names.
 
@@ -23,12 +25,12 @@ However, it is also designed to behave as much as possible like a normal
 Python module. To that end, it has the following features.
 
 - The C language requires buffers to be allocated for output and it requires
-  array sizes to be include for both input and output. The `cspyce` module,
+  array sizes to be included for both input and output. The `cspyce` module,
   instead, eliminates all extraneous inputs, and all output arguments are
   returned as a list (or as a single object if the function only returns one
   item).
 
-- The module has been fully integrated with Python's exception handling,
+- `cspyce` has been fully integrated with Python's exception handling;
   programmers can still opt to use CSPICE's error handling mechanism if they
   wish to.
 
@@ -36,8 +38,7 @@ Python module. To that end, it has the following features.
   passed by name.
 
 - All `cspyce` functions have informative docstrings, so typing
-      help(function)
-  provides useful information.
+  `help(function)` provides useful information.
 
 - Many `cspyce` functions take sensible default values if input arguments are
   omitted.
@@ -71,18 +72,38 @@ These options include:
 ---
 ## EXCEPTION HANDLING
 
-As in CSPICE, the user can designate what to do in the event of an error
-condition using function erract(). In CSPICE, those options are "RETURN",
-"REPORT", "IGNORE", "ABORT", and "DEFAULT". This function adds new options
-"EXCEPTION" and "RUNTIME" to the suite of error handling options supported by
-CPICE.
+In CSPICE, the user can designate what to do in the event of an error condition
+using the function `erract()`. In CSPICE, the available options are "RETURN",
+"REPORT", "IGNORE", "ABORT", and "DEFAULT". The `cspyce` version of this
+function adds new options "EXCEPTION" and "RUNTIME" to the suite of error
+handling options supported by CSPICE.
 
 - As usual, the user can select the exception handling mechanism to use by
   calling the function erract(). In `cspyce`, the default is "EXCEPTION".
 
-- When using one of CSPICE's error handling methods, a call to failed() will
-  reveal whethen an error has occurred, and a call to reset() is needed to
-  clear the error.
+- When using the "EXCEPTION" option, each CSPICE error condition raises a
+  Python exception rather than setting the `failed()` flag. The exception
+  contains the text of the CSPICE error, in the form (short message + " -- " +
+  long message). The CSPICE error conditions are mapped to standard Python
+  exception types in a sensible way:
+  - `KeyError` indicates that a SPICE ID or name is unrecognized.
+  - `ValueError` indicates that one of the inputs to a function had an invalid
+    value.
+  - `TypeError` indicates that one of the inputs to a function had an invalid
+    type.
+  - `IndexError` indicates that an integer index is out of range.
+  - `IOError` indicates errors with reading and writing files, including SPICE
+    kernels. IOError can also indicate that needed information was not in one
+    of the furnished kernels.
+  - `MemoryError` indicates that adequate memory could not be allocated, or
+    that the defined size of a memory buffer in C is too small.
+  - `ZeroDivisionError` indicates that a divide-by-zero has occurred.
+  - `RuntimeError` indicates that an action is incompatible with some aspect
+    of the CSPICE module's internal configuration.
+
+- When using one of CSPICE's intrinsic error handling methods, no exception
+  will be raised, but a call to `failed()` will reveal whether an error has
+  occurred. A call to `reset()` is needed to clear the error.
 
 - Care has been taken to reduce the chances that the "dangerous" options
   "IGNORE" and "REPORT" will cause a segmentation fault. However, this
@@ -90,86 +111,63 @@ CPICE.
 
 - Because it would be a highly questionable thing to do, the "ABORT" and
   "DEFAULT" options are overridden by "EXCEPTION" when the user is running
-  `cspyce` from an interactive shell. However, they resume their standard effects
-  during non-interactive runs.
-
-- When using the "EXCEPTION" option, each CSPICE error condition raises a
-  Python exception rather than setting the failed() flag. The exception
-  contains the text of the CSPICE error, in the form (short message + " -- " +
-  long message).
-
-- The CSPICE error conditions are mapped to standard Python exception types in
-  a sensible way:
-  - KeyError indicates that a SPICE ID or name is unrecognized.
-  - ValueError indicates that one of the inputs to a function had an invalid
-    value.
-  - TypeError indicates that one of the inputs to a function had an invalid
-    type.
-  - IndexError indicates that an integer index is out of range.
-  - IOError indicates errors with reading and writing files, including SPICE
-    kernels. IOError can also indicate that needed information was not in one
-    of the furnished kernels.
-  - MemoryError indicates that adequate memory could not be allocated, or
-    that the defined size of a memory buffer in C is too small.
-  - ZeroDivisionError indicates that a divide-by-zero has occurred.
-  - RuntimeError indicates that an action is incompatible with some aspect
-    of the CSPICE module's internal configuration.
+  `cspyce` from an interactive shell. However, they resume their standard
+  effects during non-interactive runs.
 
 - When using the "RUNTIME" option, each CSPICE error condition raises a
-  Python RuntimeError exception rather than setting the failed() flag. This is
-  similar to the "EXCEPTION" option except the type of exception is always the
-  same.
+  Python `RuntimeError` exception rather than setting the `failed()` flag. This
+  is similar to the "EXCEPTION" option except the type of exception is always
+  the same.
 
 - Certain out-of-memory conditions are beyond the control of the CSPICE
   library. These will always raise a MemoryError exception, regardless of the
   exception handling method chosen.
 
-HANDLING OF ERROR FLAGS: Many CSPICE functions bypass the library's own error
-handling mechanism; instead they return a status flag, sometimes called "found"
-or "ok", or perhaps an empty response to indicate failure. The `cspyce` module
-provides alternative options for these functions.
+### HANDLING OF ERROR FLAGS
+
+Many CSPICE functions bypass the library's own error handling mechanism; instead
+they return a status flag, sometimes called "found" or "ok", or perhaps an empty
+response to indicate failure. The `cspyce` module provides alternative options
+for these functions.
 
 Within `cspyce`, functions that return error flags have an alternative
 implementation with a suffix of "_error", which uses the CSPICE/`cspyce` error
-handling mechanism instead.
+handling mechanism detailed above instead.
 
-Note that most _error versions of functions have fewer return values than the
+Note that most `_error` versions of functions have fewer return values than the
 associated non-error versions. The user should be certain which version is being
 used before interpreting the returned value(s).
 
-The `cspyce` module provides several ways to control which version of the function
-to use:
+The `cspyce` module provides several ways to control which version of the
+function to use:
 
-- The function use_flags() takes a function name or list of names and designates
-  the original version of each function as the default. If the input argument is
-  missing.
+- The function `use_flags()` takes a function name or list of names and
+  designates the original version of each function as the default. If the input
+  argument is missing, original versions are selected universally.
 
-- The function use_errors() takes a function name or list of names and
-  designates the _error version of each function as the default. If the input
-  argument is missing, _error versions are selected universally. With this
-  option, for example, a call to `cspyce`1.bodn2c() will actually call
-  `cspyce`1.bodn2c_error() instead.
+- The function `use_errors()` takes a function name or list of names and
+  designates the `_error` version of each function as the default. If the input
+  argument is missing, `_error` versions are selected universally.
 
-For backward compatibilty with our original Python cspice library, the _error
-versions of all cspice functions are selected by default.
-
-You can also choose between the "flag" and "error" versions of a function using
-`cspyce` function attributes, as discussed below.
+To provide a more consistent Python interface, the `_error` versions of all
+`cspyce` functions are selected by default. You can also choose between the
+"flag" and "error" versions of a function using `cspyce` function attributes,
+as discussed below.
 
 ---
 ## VECTORS AND ARRAYS
 
 ### VECTORIZATION
 Nearly every function that takes floating-point input (be it a
-scalar, 1-D array, or 2-D array) has a vectorized version, which allows you to
+scalar, 1-D array, or 2-D array) has a vectorized version that allows you to
 pass a vector of these items in place of a single value. The CSPICE function is
-called for each of the provided inputs and the function returns a vector of
-results.
+called for each of the provided inputs, the results are collected, and the
+`cspyce` function returns a vector of results.
 
-- Vectorized versions have the same name but with "_vector" appended.
+- Vectorized versions have the same name but with `_vector` appended.
 
 - In a vectorized function, you can replace any or all floating-point input
-  parameters with a array having one extra leading dimension. Integer, boolean,
+  parameters with an array having one extra leading dimension. Integer, boolean,
   and string inputs cannot be replaced by arrays.
 
 - If no inputs have an extra dimension, then the result is the same as
@@ -182,20 +180,19 @@ results.
   to the function. The vectorized function cycles through the elements of each
   array repeatedly if necessary. It may make sense to do this if each leading
   axis is an integer fraction of the largest axis size. For example, if the
-  first input array has size 100 and the second has size 25, then the the
-  returned arrays(s) will have 100 elements and the values of the second
-  will each be used four times. However, caution is advised when using this
-  capability.
+  first input array has size 100 and the second has size 25, then the returned
+  arrays(s) will have 100 elements and the values of the second will each be
+  used four times. However, caution is advised when using this capability.
 
 - Some functions are not vectorized. These include:
   - Functions that have no floating-point inputs.
   - Functions that include strings among the returned quantities.
-  - Functions athat already return arrays where the leading axis could be
+  - Functions that already return arrays where the leading axis could be
     variable in size.
 
-- In the two cases (ckgp and ckgpav) where a function can be both vectorized
-  and either raise an error or return a flag, the "_vector" suffix comes
-  before "_error".
+- In the two cases (`ckgp` and `ckgpav`) where a function can be both vectorized
+  and either raise an error or return a flag, the `_vector` suffix comes
+  before `_error`.
 
 ### ARRAYS
 An optional import allows the `cspyce` module to support multidimensional
@@ -206,10 +203,10 @@ import cspyce
 import cspyce.arrays
 ```
 
-The latter import creates a new function in which the suffix "_array" replaces
-"_vector" for every vectorized function. Whereas _vector function support only
-a single extra dimension, _array functions follow all the standard rules of
-shape broadcasting as defined in NumPy. For example, if one input has leading
+The latter import creates a new function in which the suffix `_array` replaces
+`_vector` for every vectorized function. Whereas `_vector` functions support
+only a single extra dimension, `_array` functions follow all the standard rules
+of shape broadcasting as defined in NumPy. For example, if one input has leading
 dimension (10,4) and another has dimension (4,), then the two shapes will be
 broadcasted together and returned quantities will be arrays with shape (10,4).
 
@@ -220,8 +217,8 @@ below.
 ---
 ## ALIASES
 
-Aliases allow the user to associate multiple names or codes with the same CSPICE
-body or frame. Aliases can be used for a variety of purposes.
+Aliases allow the user to associate multiple names or SPICE codes with the same
+CSPICE body or frame. Aliases can be used for a variety of purposes.
 
 - You can use names and codes interchangeably as input arguments to any `cspyce`
   function.
@@ -230,12 +227,12 @@ body or frame. Aliases can be used for a variety of purposes.
 - Strings that represent integers are equivalent to the integers themselves.
 
 Most importantly, you can allow multiple names or codes to refer to the same
-CPSICE body or frame. For bodies and frames that have multiple names or codes,
+CSPICE body or frame. For bodies and frames that have multiple names or codes,
 calls to a `cspyce` function will try each option in sequence until it finds one
-that works. Options are always tried in the order of they were defined, so
+that works. Options are always tried in the order in which they were defined, so
 higher-priority names and codes are tried first.
 
-Example 1: Jupiter's moon Dia uses code = 553, but it previously used code
+Example 1: Jupiter's moon Dia uses code 553, but it previously used code
 55076. With 55076 defined as an alias for 553, a `cspyce` call will return
 information about Dia under either of its codes.
 
@@ -246,13 +243,13 @@ toolkit will use ITRF93 if it is available, and otherwise IAU_EARTH.
 
 Immediately after a `cspyce` call involving aliases, you can find out what value
 or values were actually used by looking at attributes of the function. For
-example, the first input to `cspyce` function spkez is called "targ" and it
-identifies the code of a target being observed. After a call to
+example, the first input to the `cspyce` function `spkez` is called `targ` and
+it identifies the code of a target being observed. After a call to
 
 ```python
 cspyce.spkez(553, ...
 ```
-the value of `cspyce`.spkez.targ will be the code actually used, in this case
+the value of `cspyce.spkez.targ` will be the code actually used, in this case
 either 553 or 55076.
 
 To enable aliases, you must import an additional module
@@ -262,34 +259,37 @@ import cspyce
 import cspyce.aliases
 ```
 
-(Note that `cspyce`.aliases and `cspyce`.arrays can both be imported, and in either
-order. Note also that these are unconventional modules, in that they introduce
-new functionality into the "`cspyce`" namespace rather than creating new
-namespaces called "`cspyce`.aliases" and "`cspyce`.arrays".)
+(Note that `cspyce.aliases` and `cspyce.arrays` can both be imported, and in
+either order. Note also that these are unconventional modules, in that they
+introduce new functionality into the `cspyce` namespace rather than creating
+new namespaces called `cspyce.aliases` and `cspyce.arrays`.)
 
 With this import, a new function is defined for every `cspyce` function that takes
 a frame or body as input. The new function has the same name as the pre-existing
-`cspyce` function, but with "_alias" inserted immediately after the original
-`cspyce` name (and before any other suffix such as "_vector" or "_error").
+`cspyce` function, but with `_alias` inserted immediately after the original
+`cspyce` name (and before any other suffix such as `_vector` or `_error`).
 
 You can make alias support the default for individual `cspyce` functions or for
-the entire `cspyce` module by calling:
-  `cspyce`.use_aliases()
-These versions can subsequently be disabled as the default by calling:
-  `cspyce`.use_noaliases()
+the entire `cspyce` module by calling `cspyce.use_aliases()`. These versions
+can subsequently be disabled as the default by calling `cspyce.use_noaliases()`
+(see more detailed discussion below).
 
 To define a body alias or frame alias, call
-  `cspyce`.define_body_aliases(name_or_code, name_or_code, ...)
-  `cspyce`.define_frame_aliases(name_or_code, name_or_code, ...)
+
+    cspyce.define_body_aliases(name_or_code, name_or_code, ...)
+    cspyce.define_frame_aliases(name_or_code, name_or_code, ...)
+
 where the arguments are an arbitrary list of codes and names.
 
 To determine the aliases associated with a name or code, call
-  `cspyce`.get_body_aliases(name_or_code)
-  `cspyce`.get_frame_aliases(name_or_code)
+
+    cspyce.get_body_aliases(name_or_code)
+    cspyce.get_frame_aliases(name_or_code)
+
 where the argument is either a name or a code.
 
 You can also select between the alias-supporting and alias-nonsupporting
-versions of a function using function attributes.
+versions of a function using function attributes as discussed below.
 
 ---
 ## FUNCTION NAMES, VERSIONS AND SELECTION METHODS
@@ -301,46 +301,51 @@ basename[_alias][_vector|_array][_error]
 ```
 Only functions that are truly distinct are defined. For example, if a function
 does not have a vector option, then no function will exist containing the
-"_vector" suffix.
+`_vector` suffix.
 
-Note that you can use these functions to set defaults:
-* `cspyce.use_flags()`
-* `cspyce.use_errors()`
-* `cspyce.use_scalars()`
-* `cspyce.use_vectors()`
-* `cspyce.use_arrays()`
-* `cspyce.use_aliases()`
-* `cspyce.use_noaliases()`
+You can use these functions to set defaults:
 
-FUNCTION ATTRIBUTES: These provide a simpler mechanism for choosing the needed
-version of a function, without remembering the suffix rules. Every `cspyce`
-function has these attributes, each of which identifies another (or possibly the
-same) `cspyce` function:
+    cspyce.use_flags()
+    cspyce.use_errors()
+    cspyce.use_scalars()
+    cspyce.use_vectors()
+    cspyce.use_arrays()
+    cspyce.use_aliases()
+    cspyce.use_noaliases()
 
-| Attribute | Docstring |
-|-----------|-----------|
-| `func.flag`|   the equivalent function without the _error suffix, if any.|
-| `func.error`|  the equivalent function with the _error suffix, if any.|
-| `func.flag`|   the equivalent function without the _error suffix, if a.|
-| `func.error`|  the equivalent function with the _error suffix, if any
-| `func.scalar`| the equivalent function without _array or _vector suffes.|
-| `func.vector`| the equivalent function with the _vector suffix, if any
-| `func.array`|  the equivalent function with the _array suffix, if any.|
-| `func.alias`|  the equivalent function with the _alias suffix, if any.|
-| `func.noalias`| the equivalent function without the _alias suffix, if any.|
+Each function can take one or more arguments referencing specific `cspyce`
+functions, in which case the defaults only apply to those functions. If no
+arguments are specified, the default applies to all functions. For example,
+to use "flags" as the default for all functions except `ckgp`, you could use:
+
+    cspyce.use_flags()
+    cspyce.use_errors(cspyce.ckgp)
+
+### FUNCTION ATTRIBUTES
+
+Function attributes provide a simpler mechanism for choosing the needed
+version of a function, without needing to remember the suffix rules. Every
+`cspyce` function has these attributes, each of which identifies another
+(or possibly the same) `cspyce` function:
+
+| Attribute      | Meaning                                                    |
+|----------------|------------------------------------------------------------|
+| `func.flag`    | the equivalent function without the _error suffix, if any. |
+| `func.error`   | the equivalent function with the _error suffix, if any.    |
+| `func.scalar`  | the equivalent function without _array or _vector suffixes.|
+| `func.vector`  | the equivalent function with the _vector suffix, if any.   |
+| `func.array`   | the equivalent function with the _array suffix, if any.    |
+| `func.alias`   | the equivalent function with the _alias suffix, if any.    |
+| `func.noalias` | the equivalent function without the _alias suffix, if any. |
 
 These attributes are always defined, even if the particular option is not
 supported by that function. This saves the programmer the effort of remembering,
 for example, which functions support aliases or which functions support flags.
 
-Thus, if the programmer wishes to be sure s/he is using the error version of
-function bodn2c, and wants the vector version if it exists (but it doesn't!),
-can call
+Thus, if the programmer wishes to be sure they are using the error version of
+function `bodn2c`, and wants the vector version if it exists (but it doesn't!),
+they can call
 
 ```python
 cspyce.bodn2c.error.vector(args...)
 ```
-
-Thus, it is never strictly necessary to refer to any function with its suffixes.
-
----

--- a/cspyce/__init__.py
+++ b/cspyce/__init__.py
@@ -1,20 +1,118 @@
-################################################################################
-# cspyce/__init__.py
-################################################################################
-# CSPYCE OVERVIEW
-#
-# cspyce is a Python module that provides an interface to the CSPICE library. It
-# implements the most widely-used functions of CSPICE in a Python-like way. It
-# also supports numerous enhancements, including support for Python exceptions,
-# array inputs, and aliases.
-#
-# This version of the library has been built for the CSPICE toolkit v. 67.
-#
-# See the file pds-cspyce/README.md for more information.
-#
-# Mark Showalter, PDS Ring-Moon Systems Node, SETI Institute, December 2017.
-#   - Adapted for Python 3, February 2022.
-################################################################################
+"""
+cspyce/__init__.py
+
+CSPYCE OVERVIEW
+
+cspyce is a Python module that provides an interface to the CSPICE library. It
+implements the most widely-used functions of CSPICE in a Python-like way. It
+also supports numerous enhancements, including support for Python exceptions,
+array inputs, and aliases.
+
+This version of the library has been built for the CSPICE toolkit v. 67.
+
+cspyce contains Python interfaces to all CSPICE functions likely to be useful
+to a Python programmer. Excluded are deprecated functions and various low-level
+functions supporting character strings, cells, sets, file I/O, and also all
+low-level "geometry finder" functions that can only be implemented in C. It
+also includes vectorized versions (with suffix "_vector") for nearly every
+function that receives floating-point input and does not perform I/O.
+
+ADDED FEATURES
+
+DOCSTRINGS
+- All cspyce functions have informative docstrings, so typing
+      help(function)
+  provides useful information. However, the call signature appearing in the
+  first line of the help text is still defined by cspyce0 and may not make
+  sense to the reader. This issue is fixed by module cspyce2.
+
+DEFAULTS
+- Many cspyce functions take sensible default values if input arguments are
+  omitted.
+  - In gcpool, gdpool, gipool, and gnpool, start values default to 1.
+  - The functions that take "SET" or "GET" as their first argument (erract,
+    errdev, errprt, and timdef) have simplified calling options, which are
+    summarized in their docstrings.
+
+RUNTIME ERROR HANDLING
+
+In the CSPICE error handling mechanism, the programmer must check the value
+of function failed() regularly to determine if an error has occurred. However,
+Python's exception handling mechanism obviates the need for this approach. In
+cspyce1, all CSPICE errors raise Python exceptions.
+
+In CSPICE, the programmer can control how C errors are handled using the
+function erract(). Options include "IGNORE", "REPORT", "ABORT", "DEFAULT",
+and "RETURN", In cspyce1, the "IGNORE" and "REPORT" options are disabled,
+because they can leave behind corrupted memory. In interactive Python, the
+"ABORT" and "DEFAULT" options are also disabled, because aborting an
+interactive session would be pointless. The "ABORT" and "DEFAULT" options are
+still available, though not recommended, when running programs
+non-interactively.
+
+The cspyce1 module supports two additional error actions, which are variants
+on "RETURN". These are "EXCEPTION" and "RUNTIME". The only difference between
+them is that "RUNTIME" consistently raises RuntimeError exceptions, whereas
+"EXCEPTION" tailors the type of the exception to the situation.
+
+HANDLING OF ERROR FLAGS
+
+Many CSPICE functions bypass the library's own error handling mechanism;
+instead they return a status flag, sometimes called "found" or "ok", or else
+an empty response might indicate failure. The cspyce module provides
+alternative options for these functions.
+
+Within cspyce1, functions that return error flags have an alternative
+implementation with a suffix of "_error", which uses cspyce1's Python
+exception handling instead. For example, bodn2c(name) is the function that
+returns two values given the name of a body, its body ID and a True/False flag
+indicating whether the name was recognized. bodn2c_error() instead just
+returns a single value, the body ID. However, it raises a Python exception
+(KeyError or RuntimeError, depending on the erract setting) if the name is not
+recognized.
+
+The cspyce1 module provides several ways to control which version of the
+function to use:
+
+- The function use_flags() takes a function name or list of names and
+  designates the original version of each function as the default. If the
+  input argument is missing, _flag versions are selected universally.  With
+  this option, for example, a call to cspyce.bodn2c() will actually call
+  cspyce1.bodn2c_flag().
+
+- The function use_errors() takes a function name or list of names and
+  designates the _error version of each function as the default. If the input
+  argument is missing, _error versions are selected universally. With this
+  option, for example, a call to cspyce1.bodn2c() will actually call
+  cspyce1.bodn2c_error() instead.
+
+You can also choose between the "flag" and "error" versions of a function
+using cspyce function attributes, as discussed below.
+
+FUNCTION ATTRIBUTES
+
+Like any other Python class, functions can have attributes. These are used to
+simplify the choices of function options in cspyce1. Every cspyce1 function
+has these attributes:
+
+  error   = the version of this function that raises exceptions intead of
+            returning flags.
+  flag    = the version that returns flags instead of raising exceptions.
+  vector  = the vectorized version of this function.
+  scalar  = the un-vectorized version of this function.
+
+If a particular option is not relevant to a function, the attribute still
+exists, and instead simply returns the function itself. This makes it trivial
+to choose a particular combination of features for a particular function call.
+For example:
+  ckgpav.vector()         same as ckgpav_vector()
+  ckgpav.vector.flag()    same as ckgpav_vector()
+  ckgpav.vector.error()   same as ckgpav_vector_error()
+  ckgpav.error.scalar()   same as ckgpav_error()
+  ckgpav.flag()           same as ckgpav()
+  bodn2c.vector()         same as bodn2c()
+  bodn2c.flag()           same as bodn2c()
+"""
 
 import inspect
 import sys
@@ -177,7 +275,7 @@ def _get_func_names(funcs=(), source=None):
 ################################################################################
 
 def get_all_funcs(source=None, cspyce_dict=None):
-    """ dictionary of all cspyce functions, keyed by their names.
+    """Return a dictionary of all cspyce functions, keyed by their names.
 
     Inputs:
         source      the dictionary to search, which defaults to globals().
@@ -212,8 +310,8 @@ def get_all_funcs(source=None, cspyce_dict=None):
     return cspyce_dict
 
 def get_all_versions(func, source=None):
-    """A dictionary of all cspyce functions associated with this one, keyed by
-    their names.
+    """Return a dictionary of all cspyce functions associated with this one,
+    keyed by their names.
 
     Inputs:
         func        a cspyce function or the name of a cspyce function.
@@ -225,7 +323,7 @@ def get_all_versions(func, source=None):
     return get_all_funcs(func.__dict__)
 
 def validate_func(func, source=None):
-    """A cspyce function, given either its name or the function itself.
+    """Return a cspyce function, given either its name or the function itself.
     Otherwise, raise an exception.
 
     Inputs:

--- a/cspyce/__init__.py
+++ b/cspyce/__init__.py
@@ -8,11 +8,11 @@
 # also supports numerous enhancements, including support for Python exceptions,
 # array inputs, and aliases.
 #
-# This version of the library has been built for the CSPICE toolkit v. 66.
+# This version of the library has been built for the CSPICE toolkit v. 67.
 #
-# See the file AAREADME.txt for more information.
+# See the file pds-cspyce/README.md for more information.
 #
-# Mark Showalter, PDS Ring-Moons Systems Node, SETI Institute, December 2017.
+# Mark Showalter, PDS Ring-Moon Systems Node, SETI Institute, December 2017.
 #   - Adapted for Python 3, February 2022.
 ################################################################################
 

--- a/cspyce/alias_support.py
+++ b/cspyce/alias_support.py
@@ -335,8 +335,7 @@ def _validate_args(func, args, keywords):
             cspyce1.sigerr('SPICE(' + body_or_frame.upper() + 'NAMENOTFOUND)')
 
 def alias_version(func):
-    """Wrapper function to support aliasing of SPICE body names or codes.
-    """
+    """Wrapper function to support aliasing of SPICE body names or codes."""
 
     if hasattr(func, 'alias'):
         return func.alias

--- a/cspyce/aliases.py
+++ b/cspyce/aliases.py
@@ -1,71 +1,71 @@
-################################################################################
-# cspyce/aliases.py
-################################################################################
-# Alias handler for the cspyce library
-#
-# Aliases allow the user to associate multiple names or codes with the same
-# CSPICE body or frame. Aliases can be used for a variety of purposes.
-#
-# - You can use names and codes interchangeably as input arguments to any cspyce
-#   function.
-# - You can use a body name or code in place of a frame name or code, and the
-#   primary frame associated with that identified body will be used.
-# - Strings that represent integers are equivalent to the integers themselves.
-#
-# Most importantly, you can allow multiple names or codes to refer to the same
-# CPSICE body or frame. For bodies and frames that have multiple names or codes,
-# calls to a cspyce function will try each option in sequence until it finds one
-# that works. Options are always tried in the order of they were defined, so
-# higher-priority names and codes are tried first.
-#
-# Example 1: Jupiter's moon Dia uses code = 553, but it previously used code
-# 55076. With 55076 defined as an alias for 553, a cspyce call will return
-# information about Dia under either of its codes.
-#
-# Example 2: The Earth's rotation is, by default, modeled by frame "IAU_EARTH".
-# However, "ITRF93" is the name of a much more precise description of Earth's
-# rotation. If you define "IAU_EARTH" as an alias for "ITRF93", then the cspyce
-# toolkit will use ITRF93 if it is available, and otherwise IAU_EARTH.
-#
-# Immediately after a cspyce call involving aliases, you can find out what value
-# or values were actually used by looking at attributes of the function. For
-# example, the first input to cspyce function spkez is called "targ" and it
-# identifies the code of a target being observed. After a call to
-#   cspyce.spkez(553, ...
-# the value of cspyce.spkez.targ will be the code actually used, in this case
-# either 553 or 55076.
-#
-# Upon importing this module, a new function is defined for every cspyce
-# function that takes a frame or body as input. The new function has the same
-# name as the pre-existing cspyce function, but with "_alias" inserted
-# immediately after the original cspyce name (and before any other suffix such
-# as "_vector" or "_error").
-#
-# You can make alias support the default for individual cspyce functions or for
-# the entire cspyce module by calling:
-#   cspyce.use_aliases()
-# These versions can subsequently be disabled as the default by calling:
-#   cspyce.use_noaliases()
-#
-# You can also select the specific version of the cspyce function via a function
-# attribute. For example, after calling
-#   cspyce.use_aliases('spkez')
-# the function cspyce.spkez will support aliases. However, calling
-#   cspyce.spkez.noalias(...)
-# will use the un-aliased version. You can also use the aliased version
-# explicitly by calling
-#   cspyce.spkez.alias(...)
-#
-# To define a body alias or frame alias, call
-#   cspyce.define_body_aliases(name_or_code, name_or_code, ...)
-#   cspyce.define_frame_aliases(name_or_code, name_or_code, ...)
-# where the arguments are an arbitrary list of codes and names.
-#
-# To determine the aliases associated with a name or code, call
-#   cspyce.get_body_aliases(name_or_code)
-#   cspyce.get_frame_aliases(name_or_code)
-# where the argument is either a name or a code.
-################################################################################
+"""
+cspyce/aliases.py
+
+Alias handler for the cspyce library
+
+Aliases allow the user to associate multiple names or codes with the same
+CSPICE body or frame. Aliases can be used for a variety of purposes.
+
+- You can use names and codes interchangeably as input arguments to any cspyce
+  function.
+- You can use a body name or code in place of a frame name or code, and the
+  primary frame associated with that identified body will be used.
+- Strings that represent integers are equivalent to the integers themselves.
+
+Most importantly, you can allow multiple names or codes to refer to the same
+CPSICE body or frame. For bodies and frames that have multiple names or codes,
+calls to a cspyce function will try each option in sequence until it finds one
+that works. Options are always tried in the order of they were defined, so
+higher-priority names and codes are tried first.
+
+Example 1: Jupiter's moon Dia uses code = 553, but it previously used code
+55076. With 55076 defined as an alias for 553, a cspyce call will return
+information about Dia under either of its codes.
+
+Example 2: The Earth's rotation is, by default, modeled by frame "IAU_EARTH".
+However, "ITRF93" is the name of a much more precise description of Earth's
+rotation. If you define "IAU_EARTH" as an alias for "ITRF93", then the cspyce
+toolkit will use ITRF93 if it is available, and otherwise IAU_EARTH.
+
+Immediately after a cspyce call involving aliases, you can find out what value
+or values were actually used by looking at attributes of the function. For
+example, the first input to cspyce function spkez is called "targ" and it
+identifies the code of a target being observed. After a call to
+  cspyce.spkez(553, ...
+the value of cspyce.spkez.targ will be the code actually used, in this case
+either 553 or 55076.
+
+Upon importing this module, a new function is defined for every cspyce
+function that takes a frame or body as input. The new function has the same
+name as the pre-existing cspyce function, but with "_alias" inserted
+immediately after the original cspyce name (and before any other suffix such
+as "_vector" or "_error").
+
+You can make alias support the default for individual cspyce functions or for
+the entire cspyce module by calling:
+  cspyce.use_aliases()
+These versions can subsequently be disabled as the default by calling:
+  cspyce.use_noaliases()
+
+You can also select the specific version of the cspyce function via a function
+attribute. For example, after calling
+  cspyce.use_aliases('spkez')
+the function cspyce.spkez will support aliases. However, calling
+  cspyce.spkez.noalias(...)
+will use the un-aliased version. You can also use the aliased version
+explicitly by calling
+  cspyce.spkez.alias(...)
+
+To define a body alias or frame alias, call
+  cspyce.define_body_aliases(name_or_code, name_or_code, ...)
+  cspyce.define_frame_aliases(name_or_code, name_or_code, ...)
+where the arguments are an arbitrary list of codes and names.
+
+To determine the aliases associated with a name or code, call
+  cspyce.get_body_aliases(name_or_code)
+  cspyce.get_frame_aliases(name_or_code)
+where the argument is either a name or a code.
+"""
 
 import cspyce
 import cspyce.alias_support as support

--- a/cspyce/array_support.py
+++ b/cspyce/array_support.py
@@ -184,7 +184,7 @@ def _exec_with_broadcasting(func, *args, **keywords):
     for indx in list(range(len(args))) + list(keywords.keys()):
 
         item = func.INPUT_ITEMS.get(indx, None)
-        if not item:
+        if item is None:
             continue
 
         rank = len(item)

--- a/cspyce/array_support.py
+++ b/cspyce/array_support.py
@@ -41,8 +41,12 @@ def _arrayize_arglist(arglist):
     return arrayized
 
 def array_version(func):
-    """Wrapper function to apply NumPy broadcasting rules to the vectorized
-    inputs of any cspyce function.
+    """Create and return the array version of a cspyce function.
+
+    The array version is a wrapper function that applies NumPy broadcasting
+    rules to the inputs of a vector function. If the array version already
+    exists, just return it. If there is no vector version, the array version is
+    simply the scalar version.
     """
 
     if hasattr(func, 'array'):

--- a/cspyce/array_support.py
+++ b/cspyce/array_support.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import numpy as np
 import sys
 import inspect
+import warnings
 
 import cspyce
 import cspyce.cspyce1 as cspyce1
@@ -16,7 +17,7 @@ from cspyce.alias_support import alias_version
 PYTHON2 = sys.version_info[0] < 3
 
 # This isn't how we want to handle a ragged array
-np.warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
+warnings.filterwarnings('ignore', category=np.VisibleDeprecationWarning)
 
 ################################################################################
 # cspyce array function wrapper
@@ -141,7 +142,7 @@ def array_version(func):
     wrapper.NOTES     = [ARRAY_NOTE] + wrapper.NOTES[1:] # replace vector note
 
     # Save key attributes of the wrapper function before returning
-    cspyce.assign_docstring(wrapper)
+    cspyce1.assign_docstring(wrapper)
     wrapper.__name__ = _array_name(func.__name__)
     if PYTHON2:
         wrapper.func_defaults = func.func_defaults
@@ -240,7 +241,7 @@ def _exec_with_broadcasting(func, *args, **keywords):
 
     # Call function now if iteration is not needed
     if not array_args:
-        return func.scalar.__call__(*args, **keywords)
+        return func.vector.__call__(*args, **keywords)
 
     # Determine the broadcasted shape
     try:

--- a/cspyce/arrays.py
+++ b/cspyce/arrays.py
@@ -1,19 +1,19 @@
-################################################################################
-# cspyce/arrays.py
-################################################################################
-# Array handler for the cspyce library
-#
-# This module implements support for multidimensional arrays by building upon
-# all of the vectorized functions in the cspyce module. Upon importing this
-# module, a new function is defined for each "_vector" function, with the same
-# name except "_array" replacing "_vector".
-#
-# The key difference is that the "_array" functions follow all of the standard
-# NumPy rules for array broadcasting. Input arguments to cspyce _array functions
-# can have arbitrary additional dimensions, as long as all those dimensions
-# broadcast together properly. The returned arrays will all have the
-# broadcasted shape.
-################################################################################
+"""
+cspyce/arrays.py
+
+Array handler for the cspyce library
+
+This module implements support for multidimensional arrays by building upon
+all of the vectorized functions in the cspyce module. Upon importing this
+module, a new function is defined for each "_vector" function, with the same
+name except "_array" replacing "_vector".
+
+The key difference is that the "_array" functions follow all of the standard
+NumPy rules for array broadcasting. Input arguments to cspyce _array functions
+can have arbitrary additional dimensions, as long as all those dimensions
+broadcast together properly. The returned arrays will all have the
+broadcasted shape.
+"""
 
 import cspyce
 import cspyce.array_support as support
@@ -36,4 +36,3 @@ if not hasattr(cspyce, 'ARRAYS_IMPORTED'):
 cspyce.ARRAYS_IMPORTED = True
 
 ################################################################################
-

--- a/cspyce/cspyce1.py
+++ b/cspyce/cspyce1.py
@@ -1,121 +1,12 @@
 ################################################################################
 # cspyce/cspyce1.py
-################################################################################
-# module cspyce.cspyce1
 #
 # This module provides several enhancements over the low-level cspyce0 interface
-# to the CSPICE library.
+# to the CSPICE library. See cspyce/__init__.py for a full explanation.
 #
-# The cspyce1 module contains Python interfaces to all CSPICE functions likely
-# to be useful to a Python programmer. Excluded are deprecated functions and
-# various low-level functions supporting character strings, cells, sets, file
-# I/O, and also all low-level "geometry finder" functions that can only be
-# implemented in C. It also includes vectorized versions (with suffix "_vector")
-# for nearly every function that receives floating-point input and does not
-# perform I/O. As of April 2022, however, some of the less-used cspice
-# functions have not yet been fully tested.
-#
-# To use cspyce1:
-#   import cspyce.cspyce1
-# or
-#   import cspyce.cspyce1 as cspyce
-#
-# ADDED FEATURES
-#
-# DOCSTRINGS
-# - All cspyce functions have informative docstrings, so typing
-#       help(function)
-#   provides useful information. However, the call signature appearing in the
-#   first line of the help text is still defined by cspyce0 and may not make
-#   sense to the reader. This issue is fixed by module cspyce2.
-#
-# DEFAULTS
-# - Many cspyce functions take sensible default values if input arguments are
-#   omitted.
-#   - In gcpool, gdpool, gipool, and gnpool, start values default to 1.
-#   - The functions that take "SET" or "GET" as their first argument (erract,
-#     errdev, errprt, and timdef) have simplified calling options, which are
-#     summarized in their docstrings.
-#
-# RUNTIME ERROR HANDLING
-#
-# In the CSPICE error handling mechanism, the programmer must check the value
-# of function failed() regularly to determine if an error has occurred. However,
-# Python's exception handling mechanism obviates the need for this approach. In
-# cspyce1, all CSPICE errors raise Python exceptions.
-#
-# In CSPICE, the programmer can control how C errors are handled using the
-# function erract(). Options include "IGNORE", "REPORT", "ABORT", "DEFAULT",
-# and "RETURN", In cspyce1, the "IGNORE" and "REPORT" options are disabled,
-# because they can leave behind corrupted memory. In interactive Python, the
-# "ABORT" and "DEFAULT" options are also disabled, because aborting an
-# interactive session would be pointless. The "ABORT" and "DEFAULT" options are
-# still available, though not recommended, when running programs
-# non-interactively.
-#
-# The cspyce1 module supports two additional error actions, which are variants
-# on "RETURN". These are "EXCEPTION" and "RUNTIME". The only difference between
-# them is that "RUNTIME" consistently raises RuntimeError exceptions, whereas
-# "EXCEPTION" tailors the type of the exception to the situation.
-#
-# HANDLING OF ERROR FLAGS
-#
-# Many CSPICE functions bypass the library's own error handling mechanism;
-# instead they return a status flag, sometimes called "found" or "ok", or else
-# an empty response might indicate failure. The cspyce module provides
-# alternative options for these functions.
-#
-# Within cspyce1, functions that return error flags have an alternative
-# implementation with a suffix of "_error", which uses cspyce1's Python
-# exception handling instead. For example, bodn2c(name) is the function that
-# returns two values given the name of a body, its body ID and a True/False flag
-# indicating whether the name was recognized. bodn2c_error() instead just
-# returns a single value, the body ID. However, it raises a Python exception
-# (KeyError or RuntimeError, depending on the erract setting) if the name is not
-# recognized.
-#
-# The cspyce1 module provides several ways to control which version of the
-# function to use:
-#
-# - The function use_flags() takes a function name or list of names and
-#   designates the original version of each function as the default. If the
-#   input argument is missing, _flag versions are selected universally.  With this
-#   option, for example, a call to cspyce.bodn2c() will actually call
-#   cspyce1.bodn2c_flag().
-#
-# - The function use_errors() takes a function name or list of names and
-#   designates the _error version of each function as the default. If the input
-#   argument is missing, _error versions are selected universally. With this
-#   option, for example, a call to cspyce1.bodn2c() will actuall call
-#   cspyce1.bodn2c_error() instead.
-#
-# You can also close between the "flag" and "error" versions of a function using
-# cspyce function attributes, as discussed below.
-#
-# FUNCTION ATTRIBUTES
-#
-# Like any other Python class, functions can have attributes. These are used to
-# simplify the choices of function options in cspyce1. Every cspyce1 function
-# has these attributes:
-#
-#   error   = the version of this function that raises errors intead of
-#             returning flags.
-#   flag    = the version that returns flags instead of raising errors.
-#   vector  = the vectorized version of this function.
-#   scalar  = the un-vectorized version of this function.
-#
-# If a particular option is not relevant to a function, the attribute still
-# exists, and instead simply returns the function itself. This makes it trivial
-# to choose a particular combination of features for a particular function call.
-# For example:
-#   ckgpav.vector()         same as ckgpav_vector()
-#   ckgpav.vector.flag()    same as ckgpav_vector()
-#   ckgpav.vector.error()   same as ckgpav_vector_error()
-#   ckgpav.error.scalar()   same as ckgpav_error()
-#   ckgpav.flag()           same as ckgpav()
-#   bodn2c.vector()         same as bodn2c()
-#   bodn2c.flag()           same as bodn2c()
+# Used internally by cspyce; not intended for direct import.
 ################################################################################
+
 from __future__ import print_function
 
 import sys

--- a/cspyce/cspyce1_info.py
+++ b/cspyce/cspyce1_info.py
@@ -6,6 +6,8 @@
 #
 # This function reads the associated cspyce0 dictionaries and updates them for
 # the cspyce1 "_error" versions.
+#
+# Used internally by cspyce; not intended for direct import.
 ################################################################################
 
 from cspyce.cspyce0_info import \

--- a/cspyce/cspyce2.py
+++ b/cspyce/cspyce2.py
@@ -1,16 +1,12 @@
 ################################################################################
 # cspyce/cspyce2.py
-################################################################################
-# module cspyce.cspyce2
 #
 # This module re-declares every cspyce1 function explicitly, with its list of
 # argument names as used by CSPICE. The practical effect is that functions in
 # cspyce2 module can be called in a fully Python-like way, the rightmost inputs
 # in any order and identified by their names.
 #
-# NOTE: This file is generated automatically using program make_cspyce2.py:
-#   python make_cspyce2.py > cspyce2.py
-#
+# Used internally by cspyce; not intended for direct import.
 ################################################################################
 
 import sys
@@ -20,7 +16,7 @@ import keyword
 PYTHON2 = sys.version_info[0] < 3
 
 # This function makes cspyce2 look the same as cspyce1. It ensures that every
-# location in the global dictionary and every function's internal link point
+# location in the global dictionary and every function's internal link point to
 # a new function of the same name.
 
 CSPYCE_FUNCTION_LOOKUP = {}

--- a/get_spice.py
+++ b/get_spice.py
@@ -2,8 +2,8 @@
 # get_spice.py
 ################################################################################
 #
-# This module is responsible for downloading the cspice source files based on whatever
-# hardware and software it is currently running on.
+# This module is responsible for downloading the CSPICE source files based on
+# whatever hardware and software it is currently running on.
 #
 # The contents of the directories
 #        <download>/cspice/src/cspice
@@ -14,10 +14,10 @@
 #
 # This module should only be called by setup.py.
 #
-# This file owes a big debt to Andrew Annex and his file:
+# This file owes a big debt to Dr. Andrew Annex and his file:
 #      https://github.com/AndrewAnnex/SpiceyPy/blob/main/get_spice.py
-# His version is much more ambitious than this and also compiles the files into a
-# shared library.
+# His version is much more ambitious than this and also compiles the files into
+# a shared library.
 ################################################################################
 
 
@@ -74,10 +74,10 @@ class GetCspice(object):
             self.root_dir, "cspice", self.host_OS + "-" + self.architecture)
 
     def download(self):
-        if Path(os.path.join(self.target_directory, "src")).is_dir() and \
-           Path(os.path.join(self.target_directory, "include")).is_dir():
+        if (Path(os.path.join(self.target_directory, "src")).is_dir() and
+            Path(os.path.join(self.target_directory, "include")).is_dir()):
             return self.target_directory
-        # Note.  Once we toss 2.7 support, this can be rewritten as "with ...."
+        # Note: Once we toss 2.7 support, this can be rewritten as "with ...."
         tmpdir = tempfile.mkdtemp()
         try:
             self.download_cspice(destination=tmpdir)
@@ -118,7 +118,8 @@ class GetCspice(object):
                         archive.extractall(destination)
                 else:
                     target_file = target_file[:-2] # remove the .Z
-                    subprocess.check_call("curl {} | gzip -d > {}".format(url, target_file), shell=True)
+                    subprocess.check_call("curl {} | gzip -d > {}".format(
+                        url, target_file), shell=True)
                     with TarFile.open(target_file, "r") as archive:
                         archive.extractall(destination)
                 os.unlink(target_file)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+coverage
+pytest

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ def do_setup():
 
     setup(
         name='cspyce',
-        version='2.0.5' + prerelease_version,
+        version='2.0.7' + prerelease_version,
         author="Mark Showalter/PDS Ring-Moon Systems Node",
         description="Low-level SWIG interface to the CSPICE library",
         ext_modules=get_extensions(),

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 
-# If you are installing this code via "pip install pds-cspyce", then you should
+# If you are installing this code via "pip install cspyce", then you should
 # never see this file.  pip automatically determines whether you need a binary
 # distribution or source distribution, and automatically builds it as needed for
 # your machine.
 #
-# If you are doing a build from sources, please read README-developers.md in this
-# directory.
+# If you are doing a build from sources, please read README-developers.md in
+# this directory.
 
 
 # We prefer setuptools, but will use distutils if setuptools isn't available
 import os
 from glob import glob
 import os
+import platform
 import subprocess
 import sys
 
@@ -22,10 +23,8 @@ from get_spice import GetCspice
 
 try:
     from setuptools import Command, setup, Extension
-    from setuptools.command.build_py import build_py
 except ImportError:
     from distutils.core import Command, setup, Extension
-    from distutils.core import setup, Extension, build_py
 
 try:
     import numpy
@@ -34,14 +33,10 @@ except ImportError:
     import numpy
 
 
-import subprocess
-import sys
-import platform
-
 PYTHON2 = sys.version_info[0] < 3
-IS_LINUX = platform.system() == 'Linux'
-IS_MACOS = platform.system() == 'Darwin'
-IS_WINDOWS = platform.system() == 'Windows'
+IS_LINUX = platform.system() == "Linux"
+IS_MACOS = platform.system() == "Darwin"
+IS_WINDOWS = platform.system() == "Windows"
 assert IS_LINUX or IS_MACOS or IS_WINDOWS
 
 
@@ -71,7 +66,7 @@ class GenerateCommand(Command):
             subprocess.check_call(command)
 
 
-# Some linkers seem to have trouble with 2400 files.  So we break it up into
+# Some linkers seem to have trouble with 2400 files, so we break it up into
 # smaller libraries with a maximum of 250 files apiece.
 
 cspice_directory = GetCspice().download()
@@ -122,7 +117,7 @@ def do_setup():
 
     setup(
         name='cspyce',
-        version='2.0.7' + prerelease_version,
+        version='2.0.8' + prerelease_version,
         author="Mark Showalter/PDS Ring-Moon Systems Node",
         description="Low-level SWIG interface to the CSPICE library",
         ext_modules=get_extensions(),
@@ -136,4 +131,3 @@ def do_setup():
     )
 
 do_setup()
-

--- a/swig/make_vectorize.py
+++ b/swig/make_vectorize.py
@@ -10,12 +10,12 @@
 # 2. A sequence of SWIG macro defintions, one for any VECTOR_ macro found in the
 #    file cspyce0.i.  This program looks for VECTOR_ at the start of line, and
 #    treats everything up to the initial parenthesis as the name of the macro.
-#    Each macro name defines a sequence of input arguments followed by a sequence of
-#    output arguments.
+#    Each macro name defines a sequence of input arguments followed by a
+#    sequence of output arguments.
 #
-# This program interprets the name of the macro and defines a SWIG inline function that
-# handles that sequence of arguments.
-####################################################################################
+# This program interprets the name of the macro and defines a SWIG inline
+# function that handles that sequence of arguments.
+################################################################################
 
 from __future__ import annotations
 

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -378,5 +378,3 @@ int return_boolean(int value);
 
 %apply (void RETURN_VOID_SIGERR) {void return_sigerr};
 void return_sigerr(void);
-
-


### PR DESCRIPTION
- Fixed various problems with `import cspyce.arrays` failing.
- Changed `np.warnings` to `warnings` since `np.warnings` was never supposed to work in the first place - it was a mistake in numpy where they didn't clean up their namespace.
- Cleaned up various comments and docstrings.
- Made the LICENSE file readable (80-character line breaks)
- Converted high-level module comments to module-level docstrings so they are visible to IDEs.
- Added requirements.txt
- Updated GitHub Python build action pypa/cibuildwheel to current version 2.12.1

The new version passes all cspyce and oops unit tests. It also builds and uploads to PyPi successfully. It can be tested with:

```
pip install -i https://test.pypi.org/simple/ cspyce==2.0.8a2
```

