### PR TITLE
Issue 39. Create typemap needed dafus()

### DIFF
--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+import numpy.testing as nt
 import cspyce.typemap_samples as ts
 
 
@@ -682,8 +683,30 @@ class TestReturnValueThroughOutvar(unittest.TestCase):
     def test_outvar_bool(self):
         self.assertIsInstance(ts.outvar_set_from_var_bool(0), bool)
         self.assertEqual(ts.outvar_set_from_var_bool(0), False)
-        self.assertEquals(ts.outvar_set_from_var_bool(1), True)
-        self.assertEquals(ts.outvar_set_from_var_bool(-100), True)
+        self.assertEqual(ts.outvar_set_from_var_bool(1), True)
+        self.assertEqual(ts.outvar_set_from_var_bool(-100), True)
+
+
+class Test_GEN_OUTPUT(unittest.TestCase):
+    def test_normal_action(self):
+        result = ts.generated_array(5)
+        self.assertEqual(result.dtype, np.zeros(0, dtype='double').dtype)
+        nt.assert_equal(result, np.arange(10, 15))
+
+    def test_negative_values(self):
+        result = ts.generated_array(-1)
+        self.assertEqual(len(result), 0)
+
+    def test_bad_arguments(self):
+        with self.assertRaises(TypeError):
+            ts.generated_array((1, 2, 3))
+        with self.assertRaises(TypeError):
+            ts.generated_array(None)
+        with self.assertRaises(TypeError):
+            ts.generated_array('a')
+
+
+
 
 
 if __name__ == '__main__':

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -1515,19 +1515,31 @@ extern void dafopr_c(
 * ic         O   Integer components.
 ***********************************************************************/
 
-%rename (dafus) dafus_c;
+%rename (dafus) my_dafus_c;
 %apply (void RETURN_VOID) {void my_dafus_c};
 %apply (ConstSpiceDouble IN_ARRAY1[ANY]) {ConstSpiceDouble sum[DAFSIZE]};
-%apply (SpiceDouble     OUT_ARRAY1[ANY]) {SpiceDouble dc[DAFSIZE]};
-%apply (SpiceInt        OUT_ARRAY1[ANY]) {SpiceInt ic[DAFSIZE]};
+%apply (SpiceInt dim, SpiceDouble GEN_OUTPUT[]) {(SpiceInt nd, SpiceDouble dc[])};
+%apply (SpiceInt dim, SpiceInt GEN_OUTPUT[]) {(SpiceInt ni, SpiceInt ic[])};
 
-extern void dafus_c(
+extern void my_dafus_c(
         ConstSpiceDouble sum[DAFSIZE],
         SpiceInt nd,
+        SpiceDouble dc[],
         SpiceInt ni,
-        SpiceDouble dc[DAFSIZE],
-        SpiceInt ic[DAFSIZE]
+        SpiceInt ic[]
 );
+
+%inline %{
+     void my_dafus_c(
+        ConstSpiceDouble sum[DAFSIZE],
+        SpiceInt nd,
+        SpiceDouble dc[],
+        SpiceInt ni,
+        SpiceInt ic[]) {
+        dafus_c(sum, nd, ni, dc, ic);
+        }
+%}
+
 
 /***********************************************************************
 * -Procedure dcyldr_c (Derivative of cylindrical w.r.t. rectangular )

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -401,3 +401,12 @@ void outvar_set_from_var_double(double INPUT, SpiceDouble* OUTPUT);
 void outvar_set_from_var_char(char INPUT, SpiceChar *OUTPUT);
 void outvar_set_from_var_bool(int INPUT, SpiceBoolean *OUTPUT);
 
+%{
+    void generated_array(int size, double array[]) {
+        for (int i = 0; i <= size; i++) {
+            array[i] = 10 + i;
+        }
+    }
+%}
+
+void generated_array(int dim, SpiceDouble GEN_OUTPUT[]);


### PR DESCRIPTION
Fix cspyce.dafus() by creating a typemap that can handle it.