### PR TITLE
Add %typemaps that turn an integer into a typed array of that size

### DIFF
--- a/cspyce/cspyce1.py
+++ b/cspyce/cspyce1.py
@@ -849,6 +849,24 @@ def _create_das_char_array(data, epos):
     itemsize = max(epos + 1, max(len(x) for x in byte_data))
     return np.array(byte_data, dtype=np.dtype(('S', itemsize)))
 
+def dasrdi(handle, first, last):
+    return cspyce0.dasrdi(handle, first, last, last - first + 1)
+
+del CSPYCE_SIGNATURES['dasrdi'][-1]
+del CSPYCE_ARGNAMES['dasrdi'][-1]
+
+def dasrdd(handle, first, last):
+    return cspyce0.dasrdd(handle, first, last, last - first + 1)
+
+del CSPYCE_SIGNATURES['dasrdd'][-1]
+del CSPYCE_ARGNAMES['dasrdd'][-1]
+
+def dafgda(handle, begin, end):
+    return cspcye0.dafgda(handle, begin, end, end - begin + 1)
+
+del CSPYCE_SIGNATURES['dafgda'][-1]
+del CSPYCE_ARGNAMES['dafgda'][-1]
+
 ################################################################################
 # For functions that return only a list of strings, don't embed the results in
 # an additional layer [].

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -702,20 +702,21 @@ class TestReturnValueThroughOutvar:
         assert ts.outvar_set_from_var_bool(1) is True
         assert ts.outvar_set_from_var_bool(-100) is True
 
-class Test_SIZED_INOUTARRAY1:
-    def test_resizes_array_no_default(self):
-        assert len(ts.sized_array_no_default(10, 20)) == 10
-        assert len(ts.sized_array_no_default(30, 20)) == 20
-        assert ts.sized_array_no_default(30, 20)[0] == 30
+class Test_SIZED_INOUT_ARRAY1:
+    def test_basic_int_to_sized_array(self):
+        assert len(ts.sized_array_plain(10)) == 10
+        assert len(ts.sized_array_plain(-1)) == 0
 
-    def test_resizes_array_with_default(self):
-        assert len(ts.sized_array_with_default(10, None)) == 10
-        assert len(ts.sized_array_with_default(100, None)) == 10
+    def test_basic_int_to_sized_array_with_size(self):
+        length, array = ts.sized_array_no_resize(10)
+        assert length == 10
+        assert len(b) == array
 
-    def test_no_resizes_array(self):
-        assert len(ts.sized_array_no_resize(10)) == 10
-        assert len(ts.sized_array_no_resize(-1)) == 0
-
+    def test_resizing_int_to_sized_array(self):
+        # We allocate with size 20, and resize to 5
+        original_length, array = ts.sized_array_with_resize(20, 5)
+        assert original_length == 20
+        assert len(array) == 5
 
 
 

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -701,3 +701,16 @@ class TestReturnValueThroughOutvar:
         assert ts.outvar_set_from_var_bool(0) is False
         assert ts.outvar_set_from_var_bool(1) is True
         assert ts.outvar_set_from_var_bool(-100) is True
+
+class Test_SIZED_INOUTARRAY1:
+    def test_resizes_array_no_default(self):
+        assert len(ts.sized_array_no_default(10, 20)) == 10
+        assert len(ts.sized_array_no_default(30, 20)) == 20
+        assert ts.sized_array_no_default(30, 20)[0] == 30
+
+    def test_resizes_array_with_default(self):
+        assert len(ts.sized_array_with_default(10, None)) == 10
+
+
+
+

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -710,6 +710,11 @@ class Test_SIZED_INOUTARRAY1:
 
     def test_resizes_array_with_default(self):
         assert len(ts.sized_array_with_default(10, None)) == 10
+        assert len(ts.sized_array_with_default(100, None)) == 10
+
+    def test_no_resizes_array(self):
+        assert len(ts.sized_array_no_resize(10)) == 10
+        assert len(ts.sized_array_no_resize(-1)) == 0
 
 
 

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -710,7 +710,7 @@ class Test_SIZED_INOUT_ARRAY1:
     def test_basic_int_to_sized_array_with_size(self):
         length, array = ts.sized_array_no_resize(10)
         assert length == 10
-        assert len(b) == array
+        assert len(array) == 10
 
     def test_resizing_int_to_sized_array(self):
         # We allocate with size 20, and resize to 5

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -1373,29 +1373,16 @@ extern void dafcls_c(
 * data       O   Data contained between `begin' and `end'.
 ***********************************************************************/
 
-%rename (dafgda) my_dafgda_c;
-%apply (void RETURN_VOID) {void my_dafgda_c};
-%apply (SpiceDouble **OUT_ARRAY1, int *SIZE1){(SpiceDouble **data, int *size)};
+%rename (dafgda) dafgda_c;
+%apply (void RETURN_VOID) {void dafgda_c};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY1){(SpiceDouble **data)};
 
-%inline %{
-    void my_dafgda_c(
+extern void dafgda_c(
         SpiceInt    handle,
         SpiceInt    begin,
         SpiceInt    end,
-        SpiceDouble **data,
-        int         *size)
-    {
-        my_assert_ge(begin, 1, "dafgda", "begin (#) must be at least 1");
-        my_assert_ge(end, begin, "dafgda", "end (#) must at least as large as begin (#)");
-        *size = end - begin + 1;
-        *data = my_malloc(*size, "dafgda");
-        if (*data) {
-            dafgda_c(handle, begin, end, *data);
-        }
-    }
-
-%}
-
+        SpiceDouble *data
+);
 
 /***********************************************************************
 * -Procedure dafgn_c ( DAF, get array name )
@@ -1531,28 +1518,20 @@ extern void dafopr_c(
 %rename (dafus) my_dafus_c;
 %apply (void RETURN_VOID) {void my_dafus_c};
 %apply (ConstSpiceDouble IN_ARRAY1[]) {ConstSpiceDouble sum[]};
-%apply (SpiceDouble **OUT_ARRAY1, int *SIZE1){(SpiceDouble **dc, int *dc_size)};
-%apply (SpiceInt **OUT_ARRAY1, int *SIZE1){(SpiceInt **ic, int *ic_size)};
+%apply (SpiceInt DIM1, SpiceDouble *SIZED_INOUT_ARRAY1) {(SpiceInt nd, SpiceDouble *dc)};
+%apply (SpiceInt DIM1, SpiceInt *SIZED_INOUT_ARRAY1) {(SpiceInt ni, SpiceInt *ic)};
 
 %inline %{
     void my_dafus_c(
         ConstSpiceDouble sum[],
         SpiceInt nd,
+        SpiceDouble *dc,
         SpiceInt ni,
-        SpiceDouble **dc,
-        int *dc_size,
-        SpiceInt **ic,
-        int *ic_size)
+        SpiceInt *ic)
     {
-        *dc = my_malloc(max(nd, 0), "dafus");
-        *ic = my_malloc(max(ni, 0), "dafus");
-        if (dc && ic) {
-            *dc_size = max(nd, 0);
-            *ic_size = max(ni, 0);
-            dafus_c(sum, nd, ni, *dc, *ic);
-        }
+        // Arguments are in the wrong order. We can't do the interweaving ourselves.
+        dafus_c(sum, nd, ni, dc, ic);
     }
-
 %}
 
 /***********************************************************************

--- a/swig/cspyce0_part2.i
+++ b/swig/cspyce0_part2.i
@@ -2477,27 +2477,16 @@ extern void dasrdc_c(
 * data       O   Data having addresses `first' through `last'.
 ***********************************************************************/
 
-%rename (dasrdd) my_dasrdd_c;
-%apply (void RETURN_VOID) {void my_dasrdd_c};
-%apply (SpiceDouble **OUT_ARRAY1, int *SIZE1){(SpiceDouble **data, int *size)};
+%rename (dasrdd) dasrdd_c;
+%apply (void RETURN_VOID) {void dasrdd_c};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY1){(SpiceDouble *data)};
 
-%inline %{
-extern void my_dasrdd_c (
+extern void dasrdd_c (
         SpiceInt            handle,
         SpiceInt            first,
         SpiceInt            last,
-        SpiceDouble         **data,
-        int                 *size)
-    {
-        my_assert_ge(first, 1, "dasrdd", "first (#) must be at least 1");
-        my_assert_ge(last, first, "dasrdd", "last (#) must be as large as first (#)");
-        *size = last - first + 1;
-        *data = my_malloc(*size, "dasrdd");
-        if (data) {
-           dasrdd_c(handle, first, last,  *data);
-        }
-    }
-%}
+        SpiceDouble         *data
+);
 
 /***********************************************************************
 * -Procedure dasrdi_c ( DAS, read data, integer )
@@ -2522,27 +2511,16 @@ extern void my_dasrdd_c (
 * data       O   Data having addresses `first' through `last'.
 ***********************************************************************/
 
-%rename (dasrdi) my_dasrdi_c;
-%apply (void RETURN_VOID) {void my_dasrdi_c};
-%apply (SpiceInt **OUT_ARRAY1, int *SIZE1){(SpiceInt **data, int *size)};
+%rename (dasrdi) dasrdi_c;
+%apply (void RETURN_VOID) {void dasrdi_c};
+%apply (SpiceInt *SIZED_INOUT_ARRAY1){(SpiceInt *data)};
 
-%inline %{
-extern void my_dasrdi_c (
+extern void dasrdi_c (
         SpiceInt            handle,
         SpiceInt            first,
         SpiceInt            last,
-        SpiceInt            **data,
-        int                 *size)
-    {
-        my_assert_ge(first, 1, "dasrdi", "first (#) must be at least 1");
-        my_assert_ge(last, first, "dasrdi", "last (#) must be as large as first (#)");
-        *size = last - first + 1;
-        *data = my_int_malloc(*size, "dasrdi");
-        if (data) {
-           dasrdi_c(handle, first, last,  *data);
-        }
-    }
-%}
+        SpiceInt            *data
+);
 
 /***********************************************************************
 * -Procedure dasrfr_c ( DAS, read file record )

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1938,9 +1938,9 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 
 %typemap(in)
     (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1)
-            (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size),
+            (PyArrayObject* pyarr=NULL),
     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[])
-            (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
+            (PyArrayObject* pyarr=NULL)
 {
     CREATE_SIZED_INOUT_ARRAY(Typecode)
 
@@ -1959,8 +1959,6 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     CREATE_SIZED_INOUT_ARRAY(Typecode)
     $1 = PyArray_DATA(pyarr);
 }
-
-
 
 %typemap(argout)
     (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1),

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1918,8 +1918,8 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 
     dimsize[0] = 0;
     $1 = PyArray_DIM(pyarr, 0);
-    $3 = dimsize;
-    $2 = PyArray_DATA(pyarr);
+    $2 = dimsize;
+    $3 = PyArray_DATA(pyarr);
 }
 
 %typemap(in)

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1915,15 +1915,19 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1)
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//     (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
+
     HANDLE_THREE_ARG_SIZED_INOUT_ARRAY1(Typecode, $1, $2, $3)
 }
 
 %typemap(in)
-    (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1, SpiceInt *SIZE1)
+    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size),
     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[], SpiceInt *SIZE1)
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
+
     HANDLE_THREE_ARG_SIZED_INOUT_ARRAY1(Typecode, $2, $1, $3)
 }
 
@@ -1933,6 +1937,7 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY1[])
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//     (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1)
     HANDLE_THREE_ARG_SIZED_INOUT_ARRAY1(Typecode, $3, $1, $2)
 }
 
@@ -1940,6 +1945,8 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (Type SIZED_INOUT_ARRAY1[ANY], SpiceInt DIM1, SpiceInt *SIZE1)
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//    (Type SIZED_INOUT_ARRAY1[ANY], SpiceInt DIM1, SpiceInt *SIZE1)
+
     HANDLE_THREE_ARG_SIZED_DEFAULT_INOUT_ARRAY1(Typecode, $1, $1_dim0, $2, $3)
 }
 
@@ -1947,6 +1954,7 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[ANY], SpiceInt *SIZE1)
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[ANY], SpiceInt *SIZE1)
     HANDLE_THREE_ARG_SIZED_DEFAULT_INOUT_ARRAY1(Typecode, $2, $2_dim0, $1, $3)
 }
 
@@ -1954,6 +1962,8 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY1[ANY])
         (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//     (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY1[ANY])
+
     HANDLE_THREE_ARG_SIZED_DEFAULT_INOUT_ARRAY1(Typecode, $3, $3_dim0, $1, $2)
 }
 
@@ -1963,6 +1973,8 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1)
             (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//     (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1)
+
     HANDLE_TWO_ARG_SIZED_INOUT_ARRAY1(Typecode, $1, $2)
 }
 
@@ -1972,6 +1984,8 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[])
             (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1], int size)
 {
+//     (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1)
+
     HANDLE_TWO_ARG_SIZED_INOUT_ARRAY1(Typecode, $2, $1)
 }
 

--- a/swig/make_cspyce0_info.py
+++ b/swig/make_cspyce0_info.py
@@ -502,8 +502,15 @@ def handle_one_function(out, records):
 
     # CSPYCE_DEFAULTS
     if defaults:
-        defaults = [repr(defaults[name]).replace("'", '"') for name in argnames]
-        out.write(f'CSPYCE_DEFAULTS["{func}"] = [{", ".join(defaults)}]\n')
+        # get the index of the smallest argument that has a default set
+        min_index = min(index for index, argname in enumerate(argnames)
+                                if argname in defaults)
+        if len(defaults) != len(argnames) - min_index:
+            raise ValueError(f"All arguments after {argnames[min_index]} "
+                             f"must have an optional value")
+
+        defaults = [repr(defaults[name]) for name in argnames[min_index:]]
+        out.write(f'CSPYCE_DEFAULTS["{func}"] = ({", ".join(defaults)},)\n')
 
 
 # Replacements for other random SPICE types

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -430,8 +430,8 @@ void outvar_set_from_var_bool(int INPUT, SpiceBoolean *OUTPUT);
 %apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
 void sized_array_no_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size);
 
-%apply (SpiceInt SIZED_INOUT_ARRAY1[30], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
-void sized_array_with_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size);
+%apply (SpiceInt SIZED_INOUT_ARRAY1[30], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt array[], SpiceInt in_size, SpiceInt *out_size)};
+void sized_array_with_default(SpiceInt new_size, SpiceInt array[], SpiceInt in_size, SpiceInt *out_size);
 
 %apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1) {(SpiceInt *array, SpiceInt in_size)};
 void sized_array_no_resize(SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1);

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -409,29 +409,22 @@ void outvar_set_from_var_char(char INPUT, SpiceChar *OUTPUT);
 void outvar_set_from_var_bool(int INPUT, SpiceBoolean *OUTPUT);
 
 %{
-    void sized_array_no_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size) {
+    void sized_array_plain(SpiceInt *array) {}
+
+    int sized_array_no_resize(SpiceDouble *array, SpiceInt in_size) { return in_size; }
+
+    int sized_array_with_resize(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size, SpiceInt new_size) {
         *out_size = new_size > in_size ? in_size : new_size;
-        for (int i = 0; i < *out_size; ++i) {
-            array[i] = new_size;
-        }
+        return in_size;
     }
 
-    void sized_array_with_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size) {
-        sized_array_no_default(new_size, array, in_size, out_size);
-    }
-
-    void sized_array_no_resize(SpiceInt *array, SpiceInt in_size) {
-        for (int i = 0; i < in_size; ++i) {
-            array[i] = in_size;
-        }
-    }
 %}
-
-%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
-void sized_array_no_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size);
-
-%apply (SpiceInt SIZED_INOUT_ARRAY1[30], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt array[], SpiceInt in_size, SpiceInt *out_size)};
-void sized_array_with_default(SpiceInt new_size, SpiceInt array[], SpiceInt in_size, SpiceInt *out_size);
+%apply (SpiceInt SIZED_INOUT_ARRAY1[]) {(SpiceInt *array)};
+void sized_array_plain(SpiceInt SIZED_INOUT_ARRAY1[]);
 
 %apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1) {(SpiceInt *array, SpiceInt in_size)};
-void sized_array_no_resize(SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1);
+int sized_array_no_resize(SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1);
+
+%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
+int sized_array_with_resize(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size, SpiceInt new_size);
+

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -408,3 +408,30 @@ void outvar_set_from_var_double(double INPUT, SpiceDouble* OUTPUT);
 void outvar_set_from_var_char(char INPUT, SpiceChar *OUTPUT);
 void outvar_set_from_var_bool(int INPUT, SpiceBoolean *OUTPUT);
 
+%{
+    void sized_array_no_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size) {
+        *out_size = new_size > in_size ? in_size : new_size;
+        for (int i = 0; i < *out_size; ++i) {
+            array[i] = new_size;
+        }
+    }
+
+    void sized_array_with_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size) {
+        sized_array_no_default(new_size, array, in_size, out_size);
+    }
+
+    void sized_array_no_resize(SpiceInt *array, SpiceInt in_size) {
+        for (int i = 0; i < in_size; ++i) {
+            array[i] = in_size;
+        }
+    }
+%}
+
+%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
+void sized_array_no_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size);
+
+%apply (SpiceInt SIZED_INOUT_ARRAY1[30], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
+void sized_array_with_default(SpiceInt new_size, SpiceInt *array, SpiceInt in_size, SpiceInt *out_size);
+
+%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1) {(SpiceInt *array, SpiceInt in_size)};
+void sized_array_no_resize(SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1);


### PR DESCRIPTION
Add a %typemap that turns an integer into a typed array of that size.

With this typemap, I realized I could vastly simplify several of recent cspyce0 methods that I had written. dasrdi, dasrdd, dasus, dasgda were all complicated just because they needed to allocate a size that wasn't obvious from the arguments, but that was obvious to Python!  

Also, currently cspyce0.i and cspyce_part2.i can handle optional arguments, but either all the arguments are optional or none of them are.  Added the hooks so that some suffix of the arguments can be optional. We'll probably want to use this someday.

Minor nitpicking bug.  Docs say that PyArray_Resize returns a PyObject* (either Py_None or NULL).  So technically, we need to DECREF it.  It might even be better if we eventually looked at its value and did something in case of an error.