### PR TITLE
More cleanup and bug fixes

### DIFF
--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -680,11 +680,6 @@ class TestReturnValueThroughOutvar:
         assert type(temp) == int
         assert temp == 5
 
-    def test_outvar_float(self):
-        result = ts.outvar_set_from_var_float(10)
-        assert type(result) is float
-        assert result == 10
-
     def test_outvar_double(self):
         result = ts.outvar_set_from_var_double(10)
         assert type(result) is float

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -713,5 +713,8 @@ class Test_SIZED_INOUT_ARRAY1:
         assert original_length == 20
         assert len(array) == 5
 
+    def test_double_array(self):
+        array = ts.sized_array_2d((11, 12))
+        assert array.shape == (11, 12)
 
 

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -32,7 +32,6 @@
 #define MAXFOV 100      // max number of vertices in a FOV
 #define MESSAGELEN 1024 // max length of an error message including null
 #define NAMELEN 65      // table names can be 64 plus one null
-#define NPLATES 10000   // max number of DSK plates or vertices
 #define SIDLEN 41       // maximum length of segment id, from spkpvn_c.c
 #define TIMELEN 60      // max length of a time string including null
 #define WINDOWS 120000  // max time windows returned
@@ -56,45 +55,8 @@ SpiceDouble *my_malloc(int count, const char *fname) {
     return result;
 }
 
-SpiceInt *my_int_malloc(int count, const char *fname) {
-    SpiceInt *result = (SpiceInt *) PyMem_Malloc(count * sizeof(SpiceInt));
-    if (!result) {
-        chkin_c(fname);
-        setmsg_c("Failed to allocate memory");
-        sigerr_c("SPICE(MALLOCFAILURE)");
-        chkout_c(fname);
-    }
-
-    return result;
-}
-
-SpiceInt *my_bool_malloc(int count, const char *fname) {
-    SpiceInt *result = (SpiceInt *) PyMem_Malloc(count * sizeof(SpiceBoolean));
-    if (!result) {
-        chkin_c(fname);
-        setmsg_c("Failed to allocate memory");
-        sigerr_c("SPICE(MALLOCFAILURE)");
-        chkout_c(fname);
-    }
-
-    return result;
-}
-
-SpiceChar *my_char_malloc(int count, const char *fname) {
-    SpiceChar *result = (SpiceChar *) PyMem_Malloc(count * sizeof(SpiceChar));
-    if (!result) {
-        chkin_c(fname);
-        setmsg_c("Failed to allocate memory");
-        sigerr_c("SPICE(MALLOCFAILURE)");
-        chkout_c(fname);
-    }
-
-    return result;
-}
-
 /* Internal routine to compare integers for equality */
 int my_assert_eq(int a, int b, const char *fname, const char *message) {
-
     if (a != b) {
         chkin_c(fname);
         setmsg_c(message);
@@ -109,7 +71,6 @@ int my_assert_eq(int a, int b, const char *fname, const char *message) {
 
 /* Internal routine to compare integers for "greater than or equal to" */
 int my_assert_ge(int a, int b, const char *fname, const char *message) {
-
     if (a < b) {
         chkin_c(fname);
         setmsg_c(message);
@@ -123,6 +84,7 @@ int my_assert_ge(int a, int b, const char *fname, const char *message) {
 }
 
 // Prototypes
+
 void frmchg_(SpiceInt    *frame1,
              SpiceInt    *frame2,
              SpiceDouble *et,
@@ -2453,8 +2415,8 @@ VECTORIZE_3d_dX__dN(edlimb, edlimb_c, NELLIPSE)
 *    trmpts     O   Array of terminator points.
 ***********************************************************************/
 
-%rename (edterm) my_edterm_c;
-%apply (void RETURN_VOID) {void my_edterm_c};
+%rename (edterm) edterm_c;
+%apply (void RETURN_VOID) {void edterm_c};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *trmtyp};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *source};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *target};
@@ -2463,11 +2425,9 @@ VECTORIZE_3d_dX__dN(edlimb, edlimb_c, NELLIPSE)
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (SpiceDouble *OUTPUT)          {SpiceDouble *trgepc};
 %apply (SpiceDouble OUT_ARRAY1[ANY])  {SpiceDouble obspos[3]};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                                {(SpiceDouble **trmpts, SpiceInt *dim1, SpiceInt *dim2)};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *trmpts[3]};
 
-%inline %{
-    void my_edterm_c(
+extern void edterm_c(
         ConstSpiceChar *trmtyp,
         ConstSpiceChar *source,
         ConstSpiceChar *target,
@@ -2478,28 +2438,8 @@ VECTORIZE_3d_dX__dN(edlimb, edlimb_c, NELLIPSE)
         SpiceInt       npts,
         SpiceDouble    *trgepc,
         SpiceDouble    obspos[3],
-        SpiceDouble    **trmpts, SpiceInt *dim1, SpiceInt *dim2)
-    {
-        *trmpts = NULL;
-        *dim1 = 0;
-        *dim2 = 3;
-
-        SpiceDouble *result = my_malloc(npts * 3, "edterm");
-        if (!result) return;
-
-        edterm_c(trmtyp, source, target, et, fixref, abcorr, obsrvr, npts,
-                 trgepc, obspos, result);
-
-        if (failed_c()) {
-            PyMem_Free(result);
-            return;
-        }
-
-        *trmpts = result;
-        *dim1 = npts;
-        *dim2 = 3;
-    }
-%}
+        SpiceDouble    *trmpts[3]
+);
 
 /***********************************************************************
 * -Procedure el2cgv_c ( Ellipse to center and generating vectors )
@@ -3360,12 +3300,14 @@ extern void frinfo_c(
     }
 %}
 
+%{
 extern void frmchg_(
     SpiceInt    *frame1,
     SpiceInt    *frame2,
     SpiceDouble *et,
     SpiceDouble *xform
 );
+%}
 
 //Vector version
 VECTORIZE_2i_d__dMN(frmchg, my_frmchg, 6, 6)
@@ -4622,44 +4564,23 @@ VECTORIZE_3d__dN(latrec, latrec_c, 3)
 *    srfpts     O   Array of surface points.
 ***********************************************************************/
 
-%rename (latsrf) my_latsrf_c;
-%apply (void RETURN_VOID) {void my_latsrf_c};
+%rename (latsrf) latsrf_c;
+%apply (void RETURN_VOID) {void latsrf_c};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *method};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *target};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *fixref};
-%apply (ConstSpiceDouble IN_ARRAY2[][ANY], SpiceInt DIM1)
-                            {(ConstSpiceDouble lonlat[][2], SpiceInt npts)};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                            {(SpiceDouble **srfpts, SpiceInt *sdim1, SpiceInt *sdim2)};
+%apply (SpiceInt DIM1, ConstSpiceDouble IN_ARRAY2[][ANY])
+                            {(SpiceInt npts, ConstSpiceDouble lonlat[][2])};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *srfpts[3]};
 
-%inline %{
-    void my_latsrf_c(
+extern void latsrf_c(
         ConstSpiceChar   *method,
         ConstSpiceChar   *target,
         SpiceDouble      et,
         ConstSpiceChar   *fixref,
-        ConstSpiceDouble lonlat[][2], SpiceInt npts,
-        SpiceDouble      **srfpts, SpiceInt *sdim1, SpiceInt *sdim2)
-    {
-        *srfpts = NULL;
-        *sdim1 = 0;
-        *sdim2 = 3;
-
-        SpiceDouble *srfpts1 = my_malloc(npts * 3, "latsrf");
-        if (!srfpts1) return;
-
-        latsrf_c(method, target, et, fixref, npts, lonlat, srfpts1);
-
-        if (failed_c()) {
-            PyMem_Free(srfpts1);
-            return;
-        }
-
-        *srfpts = srfpts1;
-        *sdim1 = npts;
-        *sdim2 = 3;
-    }
-%}
+        SpiceInt         npts, ConstSpiceDouble lonlat[][2],
+        SpiceDouble      *srfpts[3]
+);
 
 /***********************************************************************
 * -Procedure latsph_c ( Latitudinal to spherical coordinates )
@@ -4781,7 +4702,7 @@ extern void ldpool_c(
 *    tangts     O   Tangent vectors emanating from the observer.
 ***********************************************************************/
 
-%rename (limbpt) my_limbpt_c;
+%rename (limbpt) limbpt_c;
 %apply (void RETURN_VOID) {void my_limbpt_c};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *method};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *target};
@@ -4790,17 +4711,12 @@ extern void ldpool_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *corloc};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (ConstSpiceDouble IN_ARRAY1[ANY]) {ConstSpiceDouble refvec[3]};
-%apply (SpiceInt **OUT_ARRAY1, SpiceInt *SIZE1)
-                               {(SpiceInt **npts, SpiceInt *ndim1)};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                               {(SpiceDouble **points, SpiceInt *pdim1, SpiceInt *pdim2)};
-%apply (SpiceDouble **OUT_ARRAY1, SpiceInt *SIZE1)
-                               {(SpiceDouble **epochs, SpiceInt *edim1)};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                               {(SpiceDouble **tangts, SpiceInt *tdim1, SpiceInt *tdim2)};
+%apply (SpiceInt *SIZED_INOUT_ARRAY1) {SpiceInt *npts};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *points[3]};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY1) {SpiceDouble *epochs};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *tangts[3]};
 
-%inline %{
-    void my_limbpt_c(
+extern void limbpt_c(
         ConstSpiceChar   *method,
         ConstSpiceChar   *target,
         SpiceDouble      et,
@@ -4814,66 +4730,11 @@ extern void ldpool_c(
         SpiceDouble      schstp,
         SpiceDouble      soltol,
         SpiceInt         maxn,
-        SpiceInt         **npts,
-        SpiceInt         *ndim1,
-        SpiceDouble **points, SpiceInt *pdim1, SpiceInt *pdim2,
-        SpiceDouble **epochs, SpiceInt *edim1,
-        SpiceDouble **tangts, SpiceInt *tdim1, SpiceInt *tdim2)
-    {
-        *npts = NULL;
-        *ndim1 = 0;
-
-        *points = NULL;
-        *pdim1 = 0;
-        *pdim2 = 3;
-
-        *epochs = NULL;
-        *edim1 = 0;
-
-        *tangts = NULL;
-        *tdim1 = 0;
-        *tdim2 = 3;
-
-        SpiceInt    *npts1 = my_int_malloc(maxn,   "limbpt");
-        SpiceDouble *points1 = my_malloc(maxn * 3, "limbpt");
-        SpiceDouble *epochs1 = my_malloc(maxn,     "limbpt");
-        SpiceDouble *tangts1 = my_malloc(maxn * 3, "limbpt");
-
-        if (!tangts1) {
-            PyMem_Free(npts1);
-            PyMem_Free(points1);
-            PyMem_Free(epochs1);
-            PyMem_Free(tangts1);
-            return;
-        }
-
-        limbpt_c(method, target, et, fixref, abcorr, corloc, obsrvr, refvec,
-                 rolstp, ncuts, schstp, soltol, maxn,
-                 npts1, points1, epochs1, tangts1);
-
-        if (failed_c()) {
-            PyMem_Free(npts1);
-            PyMem_Free(points1);
-            PyMem_Free(epochs1);
-            PyMem_Free(tangts1);
-            return;
-        }
-
-        *npts = npts1;
-        *ndim1 = maxn;
-
-        *points = points1;
-        *pdim1 = maxn;
-        *pdim2 = 3;
-
-        *epochs = epochs1;
-        *edim1 = maxn;
-
-        *tangts = tangts1;
-        *tdim1 = maxn;
-        *tdim2 = 3;
-    }
-%}
+        SpiceInt         *npts,
+        SpiceDouble      *points[3],
+        SpiceDouble      *epochs,
+        SpiceDouble      *tangts[3]
+);
 
 /***********************************************************************
 * -Procedure lspcn_c  ( Longitude of the sun, planetocentric )
@@ -5121,7 +4982,9 @@ VECTORIZE_dXY__dMN(mequ, mequ_c, 3, 3)
         *nr_out = nr;
         *nc_out = nc;
     }
+%}
 
+%{
     void my_mequg_nomalloc(
         ConstSpiceDouble *m1, SpiceInt nr, SpiceInt nc,
         SpiceDouble  *matrix, SpiceInt *nr_out, SpiceInt *nc_out)
@@ -5237,7 +5100,9 @@ VECTORIZE_dXY_dXY__dMN(mtxm, mtxm_c, 3, 3)
         *nr3 = nc1;
         *nc3 = nc2;
     }
+%}
 
+%{
     void my_mtxmg_nomalloc(
         SpiceDouble *m1, SpiceInt  nr1, SpiceInt  nc1,
         SpiceDouble *m2, SpiceInt  nr2, SpiceInt  nc2,
@@ -5353,7 +5218,9 @@ VECTORIZE_dXY_dX__dN(mtxv, mtxv_c, 3)
         *v3 = result;
         *nr3 = nc1;
     }
+%}
 
+%{
     void my_mtxvg_nomalloc(
         ConstSpiceDouble *m1, SpiceInt nr1, SpiceInt nc1,
         ConstSpiceDouble *v2, SpiceInt nr2,
@@ -5471,7 +5338,8 @@ VECTORIZE_dXY_dXY__dMN(mxm, mxm_c, 3, 3)
         *nr3 = nr1;
         *nc3 = nc2;
     }
-
+%}
+%{
     void my_mxmg_nomalloc(
         SpiceDouble *m1, SpiceInt  nr1, SpiceInt  nc1,
         SpiceDouble *m2, SpiceInt  nr2, SpiceInt  nc2,
@@ -5591,7 +5459,9 @@ VECTORIZE_dXY_dXY__dMN(mxmt, mxmt_c, 3, 3)
         *nr3 = nr1;
         *nc3 = nr2;
     }
+%}
 
+%{
     void my_mxmtg_nomalloc(
         SpiceDouble *m1, SpiceInt nr1, SpiceInt nc1,
         SpiceDouble *m2, SpiceInt nr2, SpiceInt nc2,
@@ -5706,7 +5576,9 @@ VECTORIZE_dXY_dX__dN(mxv, mxv_c, 3)
         *v3 = result;
         *nr3 = nr1;
     }
+%}
 
+%{
     void my_mxvg_nomalloc(
         SpiceDouble *m1, SpiceInt nr1, SpiceInt nc1,
         SpiceDouble *v2, SpiceInt nr2,
@@ -7449,12 +7321,14 @@ VECTORIZE_dX__3d(recsph, recsph_c)
     }
 %}
 
+%{
 extern void refchg_(
     SpiceInt    *frame1,
     SpiceInt    *frame2,
     SpiceDouble *et,
     SpiceDouble *rotate
 );
+%}
 
 // Vector version
 VECTORIZE_2i_d__dMN(refchg, my_refchg, 3, 3)
@@ -9377,44 +9251,24 @@ extern void srfcss_c(
 *               P   Default point-surface membership margin.
 ***********************************************************************/
 
-%rename (srfnrm) my_srfnrm_c;
-%apply (void RETURN_VOID) {void my_srfnrm_c};
+%rename (srfnrm) srfnrm_c;
+%apply (void RETURN_VOID) {void srfnrm_c};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *method};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *target};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *fixref};
 %apply (SpiceInt DIM1, ConstSpiceDouble IN_ARRAY2[][ANY])
                           {(SpiceInt npts, ConstSpiceDouble srfpts[][3])};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                          {(SpiceDouble **normls, SpiceInt *dim1, SpiceInt *dim2)};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *normls[3]};
 
-%inline %{
-    void my_srfnrm_c(
+extern void srfnrm_c(
         ConstSpiceChar *method,
         ConstSpiceChar *target,
         SpiceDouble    et,
         ConstSpiceChar *fixref,
         SpiceInt npts, ConstSpiceDouble srfpts[][3],
-        SpiceDouble **normls, SpiceInt *dim1, SpiceInt *dim2)
-    {
-        *normls = NULL;
-        *dim1 = 0;
-        *dim2 = 3;
+        SpiceDouble    *normls[3]
+);
 
-        SpiceDouble *result = my_malloc(npts * 3, "srfnrm");
-        if (!result) return;
-
-        srfnrm_c(method, target, et, fixref, npts, srfpts, result);
-
-        if (failed_c()) {
-            PyMem_Free(result);
-            return;
-        }
-
-        *normls = result;
-        *dim1 = npts;
-        *dim2 = 3;
-    }
-%}
 
 /***********************************************************************
 * -Procedure srfrec_c ( Surface to rectangular coordinates )
@@ -9747,6 +9601,7 @@ VECTORIZE_2s_d_3s_dX__dM_2d_dN_b(srfxpt, srfxpt_c, 3, 3)
 
 %rename (stcl01) my_stcl01;
 %apply (void RETURN_VOID) {void my_stcl01};
+%apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *catfnm};
 %apply (SpiceChar OUT_STRING[ANY]) {SpiceChar tabnam[NAMELEN]};
 %apply (SpiceInt *OUTPUT)          {SpiceInt *handle};
 
@@ -10391,8 +10246,8 @@ VECTORIZE_2s_d__dMN(sxform, sxform_c, 6, 6)
 *    trmvcs     O   Terminator vectors emanating from the observer.
 ***********************************************************************/
 
-%rename (termpt) my_termpt_c;
-%apply (void RETURN_VOID) {void my_termpt_c};
+%rename (termpt) termpt_c;
+%apply (void RETURN_VOID) {void termpt_c};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *method};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *ilusrc};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *target};
@@ -10401,18 +10256,13 @@ VECTORIZE_2s_d__dMN(sxform, sxform_c, 6, 6)
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *corloc};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (ConstSpiceDouble IN_ARRAY1[ANY]) {ConstSpiceDouble refvec[3]};
-%apply (SpiceInt **OUT_ARRAY1, SpiceInt *SIZE1)
-                               {(SpiceInt **npts, SpiceInt *ndim1)};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                               {(SpiceDouble **points, SpiceInt *pdim1, SpiceInt *pdim2)};
-%apply (SpiceDouble **OUT_ARRAY1, SpiceInt *SIZE1)
-                               {(SpiceDouble **epochs, SpiceInt *edim1)};
-%apply (SpiceDouble **OUT_ARRAY2, SpiceInt *SIZE1, SpiceInt *SIZE2)
-                               {(SpiceDouble **trmvcs, SpiceInt *tdim1, SpiceInt *tdim2)};
+%apply (SpiceInt *SIZED_INOUT_ARRAY1) {SpiceInt *npts};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *points[3]};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY1) {SpiceDouble *epochs};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY2[ANY]) {SpiceDouble *trmvcs[3]};
 
 
-%inline %{
-    void my_termpt_c(
+extern void termpt_c(
         ConstSpiceChar   *method,
         ConstSpiceChar   *ilusrc,
         ConstSpiceChar   *target,
@@ -10427,65 +10277,11 @@ VECTORIZE_2s_d__dMN(sxform, sxform_c, 6, 6)
         SpiceDouble      schstp,
         SpiceDouble      soltol,
         SpiceInt         maxn,
-        SpiceInt    **npts,   SpiceInt *ndim1,
-        SpiceDouble **points, SpiceInt *pdim1, SpiceInt *pdim2,
-        SpiceDouble **epochs, SpiceInt *edim1,
-        SpiceDouble **trmvcs, SpiceInt *tdim1, SpiceInt *tdim2)
-    {
-        *npts = NULL;
-        *ndim1 = 0;
-
-        *points = NULL;
-        *pdim1 = 0;
-        *pdim2 = 3;
-
-        *epochs = NULL;
-        *edim1 = 0;
-
-        *trmvcs = NULL;
-        *tdim1 = 0;
-        *tdim2 = 3;
-
-        SpiceInt    *npts1 = my_int_malloc(maxn,   "termpt");
-        SpiceDouble *points1 = my_malloc(maxn * 3, "termpt");
-        SpiceDouble *epochs1 = my_malloc(maxn,     "termpt");
-        SpiceDouble *trmvcs1 = my_malloc(maxn * 3, "termpt");
-
-        if (!trmvcs1) {
-            PyMem_Free(npts1);
-            PyMem_Free(points1);
-            PyMem_Free(epochs1);
-            PyMem_Free(trmvcs1);
-            return;
-        }
-
-        termpt_c(method, ilusrc, target, et, fixref, abcorr, corloc, obsrvr,
-                 refvec, rolstp, ncuts, schstp, soltol, maxn,
-                 npts1, points1, epochs1, trmvcs1);
-
-        if (failed_c()) {
-            PyMem_Free(npts1);
-            PyMem_Free(points1);
-            PyMem_Free(epochs1);
-            PyMem_Free(trmvcs1);
-            return;
-        }
-
-        *npts = npts1;
-        *ndim1 = maxn;
-
-        *points = points1;
-        *pdim1 = maxn;
-        *pdim2 = 3;
-
-        *epochs = epochs1;
-        *edim1 = maxn;
-
-        *trmvcs = trmvcs1;
-        *tdim1 = maxn;
-        *tdim2 = 3;
-    }
-%}
+        SpiceInt         *npts,
+        SpiceDouble      *points[3],
+        SpiceDouble      *epochs,
+        SpiceDouble      *trmvcs[3]
+);
 
 /***********************************************************************
 * -Procedure timdef_c ( Time Software Defaults )
@@ -11142,37 +10938,21 @@ VECTORIZE_dX__dN_d(unorm, unorm_c, 3)
 * vmag      O     Magnitude of v1, that is, |v1|.
 ***********************************************************************/
 
-%rename (unormg) my_unormg_c;
-%apply (void RETURN_VOID) {void my_unormg_c};
+%rename (unormg) unormg_c;
+%apply (void RETURN_VOID) {void unormg_c};
 %apply (ConstSpiceDouble *IN_ARRAY1, SpiceInt DIM1)
                              {(ConstSpiceDouble *v1, SpiceInt ndim)};
-%apply (SpiceDouble **OUT_ARRAY1, SpiceInt *SIZE1)
-                             {(SpiceDouble **vector, SpiceInt *nd2)};
+%apply (SpiceDouble *SIZED_INOUT_ARRAY1) {SpiceDouble *vector};
 %apply (SpiceDouble *OUTPUT) {SpiceDouble *vmag};
 
-%inline %{
-    void my_unormg_c(
+extern void unormg_c(
         ConstSpiceDouble *v1, SpiceInt ndim,
-        SpiceDouble **vector, SpiceInt *nd2,
-        SpiceDouble    *vmag)
-    {
-        *vector = NULL;
-        *nd2 = 0;
+        SpiceDouble      *vector,
+        SpiceDouble      *vmag
+);
 
-        SpiceDouble *result = my_malloc(ndim, "unormg");
-        if (!result) return;
 
-        unormg_c(v1, ndim, result, vmag);
-
-        if (failed_c()) {
-            PyMem_Free(result);
-            return;
-        }
-
-        *vector = result;
-        *nd2 = ndim;
-    }
-
+%{
     void my_unormg_nomalloc(ConstSpiceDouble *v1, SpiceInt ndim,
                             SpiceDouble  *vector, SpiceInt *nd2,
                             SpiceDouble    *vmag)
@@ -11309,7 +11089,9 @@ VECTORIZE_dX_dX__dN(vadd, vadd_c, 3)
         *v3 = result;
         *nd3 = ndim;
     }
+%}
 
+%{
     void my_vaddg_nomalloc(ConstSpiceDouble *v1, SpiceInt ndim,
                     ConstSpiceDouble *v2, SpiceInt nd2,
                     SpiceDouble      *v3, SpiceInt *nd3)
@@ -11602,7 +11384,9 @@ VECTORIZE_dX__dN(vequ, vequ_c, 3)
         *v2 = result;
         *nd2 = ndim;
     }
+%}
 
+%{
     void my_vequg_nomalloc(
         ConstSpiceDouble *v1, SpiceInt ndim,
         SpiceDouble      *v2, SpiceInt *nd2)
@@ -11698,7 +11482,9 @@ VECTORIZE_dX__dN(vhat, vhat_c, 3)
         *v2 = result;
         *nd2 = ndim;
     }
+%}
 
+%{
     void my_vhatg_nomalloc(
         ConstSpiceDouble *v1, SpiceInt ndim,
         SpiceDouble      *v2, SpiceInt *nd2)
@@ -11869,7 +11655,9 @@ VECTORIZE_d_dX_d_dX__dN(vlcom, vlcom_c, 3)
         *v3 = result;
         *nd3 = n;
     }
+%}
 
+%{
     void my_vlcomg_nomalloc(
         SpiceDouble       a,
         ConstSpiceDouble *v1, SpiceInt  n,
@@ -11938,7 +11726,9 @@ VECTORIZE_d_di_d_di__di(vlcomg, my_vlcomg_nomalloc)
         *v2 = result;
         *nd2 = ndim;
     }
+%}
 
+%{
     void my_vminug_nomalloc(
         ConstSpiceDouble *v1, SpiceInt ndim,
         SpiceDouble      *v2, SpiceInt *nd2)
@@ -12443,7 +12233,9 @@ VECTORIZE_d_dX__dN(vscl, vscl_c, 3)
         *v2 = result;
         *nd2 = ndim;
     }
+%}
 
+%{
     void my_vsclg_nomalloc(
         SpiceDouble s,
         ConstSpiceDouble   *v1, SpiceInt  ndim,
@@ -12634,7 +12426,9 @@ VECTORIZE_dX_dX__dN(vsub, vsub_c, 3)
         *v3 = result;
         *nd3 = ndim;
     }
+%}
 
+%{
     void my_vsubg_nomalloc(
         ConstSpiceDouble *v1, SpiceInt ndim,
         ConstSpiceDouble *v2, SpiceInt nd2,
@@ -13093,7 +12887,9 @@ VECTORIZE_dXY__dMN(xpose, xpose_c, 3, 3)
         *nrow1 = ncol;
         *nc1 = nrow;
     }
+%}
 
+%{
     void my_xposeg_nomalloc(
         ConstSpiceDouble *matrix, SpiceInt nrow, SpiceInt  ncol,
         SpiceDouble      *xposem, SpiceInt *nrow1, SpiceInt *nc1)

--- a/swig/cspyce0_part2.i
+++ b/swig/cspyce0_part2.i
@@ -365,7 +365,7 @@ extern SpiceInt bsrchd_c(
         SpiceInt    ndim, ConstSpiceDouble *array
 );
 
-%inline %{
+%{
     SpiceInt my_bsrchd_vector(
         SpiceDouble value,
         ConstSpiceDouble *array, SpiceInt ndim)
@@ -1323,6 +1323,7 @@ extern void ckw03_c(
 
 %rename (ckw05) my_ckw05_c;
 %apply (void RETURN_VOID) {void my_ckw05_c};
+%apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *subtyp};
 %apply (SpiceInt DIM1, ConstSpiceDouble *IN_ARRAY1)
                                      {(SpiceInt n, ConstSpiceDouble *sclkdp)};
 %apply (ConstSpiceDouble *IN_ARRAY2) {ConstSpiceDouble *packts};
@@ -1405,7 +1406,7 @@ extern void ckw03_c(
 extern void cmprss_c(
         SpiceChar      delim,
         SpiceInt       n,
-        ConstSpiceChar *CONST_STRING,
+        ConstSpiceChar *input,
         SpiceInt       outlen, SpiceChar output[LONGMSGLEN]
 );
 
@@ -3829,8 +3830,11 @@ extern void dskv02_c(
 
 %rename (dskw02) dskw02_c;
 %apply (void RETURN_VOID) {void dskw02_c};
+%apply (ConstSpiceDouble IN_ARRAY1[]) {ConstSpiceDouble corpar[]};
 %apply (SpiceInt DIM1, ConstSpiceDouble IN_ARRAY2[][ANY]) {(SpiceInt nv, ConstSpiceDouble vrtces[][3])};
 %apply (SpiceInt DIM1, ConstSpiceInt IN_ARRAY2[][ANY]) {(SpiceInt np, ConstSpiceInt plates[][3])};
+%apply (ConstSpiceDouble IN_ARRAY1[]) {ConstSpiceDouble spaixd[]};
+%apply (ConstSpiceInt IN_ARRAY1[]) {ConstSpiceInt spaixi[]};
 
 extern void dskw02_c(
         SpiceInt         handle,
@@ -6157,19 +6161,21 @@ extern SpiceInt esrchc_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *gquant};
 %apply (SpiceInt DIM1, SpiceInt DIM2, ConstSpiceChar *IN_STRINGS)
                 {(SpiceInt qnpars, SpiceInt ignore, ConstSpiceChar *qpnams)};
-%apply (ConstSpiceChar *IN_STRINGS) {ConstSpiceChar *qcpars};
+%apply (SpiceInt DIM1, SpiceInt DIM2, ConstSpiceChar *IN_STRINGS)
+                {(SpiceInt ignore2, SpiceInt ignore3, ConstSpiceChar *qcpars)};
 %apply (ConstSpiceDouble  *IN_ARRAY1) {ConstSpiceDouble  *qdpars};
 %apply (ConstSpiceInt     *IN_ARRAY1) {ConstSpiceInt     *qipars};
 %apply (ConstSpiceBoolean *IN_ARRAY1) {ConstSpiceBoolean *qlpars};
+%apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar    *op};
 %apply (SpiceDouble OUT_ARRAY2[ANY][ANY], SpiceInt *SIZE1)
                 {(SpiceDouble windows[WINDOWS][2], SpiceInt *intervals)};
 
 %inline %{
     void my_gfevnt_c(
-        SpiceDouble  step,
+        SpiceDouble       step,
         ConstSpiceChar    *gquant,
         SpiceInt          qnpars, SpiceInt ignore, ConstSpiceChar *qpnams,
-        ConstSpiceChar    *qcpars,
+        SpiceInt          ignore2, SpiceInt ignore3, ConstSpiceChar *qcpars,
         ConstSpiceDouble  *qdpars,
         ConstSpiceInt     *qipars,
         ConstSpiceBoolean *qlpars,
@@ -6490,6 +6496,7 @@ extern SpiceInt esrchc_c(
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *fframe};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *back};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *bshape};
+%apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *bframe};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *abcorr};
 %apply (ConstSpiceChar *CONST_STRING) {ConstSpiceChar *obsrvr};
 %apply (SpiceDouble OUT_ARRAY2[ANY][ANY], SpiceInt *SIZE1)
@@ -8900,20 +8907,14 @@ extern void nthwd_c(
 %apply (void RETURN_VOID) {void my_orderc_c};
 %apply (SpiceInt DIM1, SpiceInt DIM2, ConstSpiceChar *IN_STRINGS)
                 {(SpiceInt ndim, SpiceInt arrlen, ConstSpiceChar *array)};
-%apply (SpiceInt *SIZE1, SpiceInt **OUT_ARRAY1) {(SpiceInt *n, SpiceInt **iorder)};
+%apply (SpiceInt *SIZED_INOUT_ARRAY1) {SpiceInt *iorder};
 
 %inline %{
     void my_orderc_c(
         SpiceInt ndim, SpiceInt arrlen, ConstSpiceChar *array,
-        SpiceInt *n,   SpiceInt **iorder)
+        SpiceInt *iorder)
     {
-        SpiceInt *iorder1 = my_int_malloc(ndim, "orderc");
-        if (!iorder1) return;
-
-        orderc_c(arrlen, array, ndim, iorder1);
-
-        *n = ndim;
-        *iorder = iorder1;
+        orderc_c(arrlen, array, ndim, iorder);
     }
 %}
 
@@ -8938,28 +8939,17 @@ extern void nthwd_c(
 * iorder     O   Order vector for array.
 ***********************************************************************/
 
-%rename (orderd) my_orderd_c;
-%apply (void RETURN_VOID) {void my_orderd_c};
+%rename (orderd) orderd_c;
+%apply (void RETURN_VOID) {void orderd_c};
 %apply (ConstSpiceDouble *IN_ARRAY1, SpiceInt DIM1)
                 {(ConstSpiceDouble *array, SpiceInt ndim)};
-%apply (SpiceInt *SIZE1, SpiceInt **OUT_ARRAY1)
-                {(SpiceInt *n, SpiceInt **iorder)};
+%apply (SpiceInt *SIZED_INOUT_ARRAY1) {SpiceInt *iorder};
 
-%inline %{
-    void my_orderd_c(
+extern void orderd_c(
         ConstSpiceDouble *array,
         SpiceInt         ndim,
-        SpiceInt         *n, SpiceInt **iorder)
-    {
-        SpiceInt *iorder1 = my_int_malloc(ndim, "orderd");
-        if (!iorder1) return;
-
-        orderd_c(array, ndim, iorder1);
-
-        *n = ndim;
-        *iorder = iorder1;
-    }
-%}
+        SpiceInt         *iorder
+);
 
 /***********************************************************************
 * -Procedure orderi_c ( Order of an integer array )
@@ -8982,26 +8972,16 @@ extern void nthwd_c(
 * iorder     O    Order vector for array.
 ***********************************************************************/
 
-%rename (orderi) my_orderi_c;
-%apply (void RETURN_VOID) {void my_orderi_c};
+%rename (orderi) orderi_c;
+%apply (void RETURN_VOID) {void orderi_c};
 %apply (ConstSpiceInt *IN_ARRAY1, SpiceInt DIM1)
                 {(ConstSpiceInt *array, SpiceInt ndim)};
-%apply (SpiceInt *SIZE1, SpiceInt **OUT_ARRAY1) {(SpiceInt *n, SpiceInt **iorder)};
+%apply (SpiceInt *SIZED_INOUT_ARRAY1) {SpiceInt *iorder};
 
-%inline %{
-    void my_orderi_c(
+extern void orderi_c(
         ConstSpiceInt *array, SpiceInt ndim,
-        SpiceInt      *n,     SpiceInt **iorder)
-    {
-        SpiceInt *iorder1 = my_int_malloc(ndim, "orderi");
-        if (!iorder1) return;
-
-        orderi_c(array, ndim, iorder1);
-
-        *n = ndim;
-        *iorder = iorder1;
-    }
-%}
+        SpiceInt      *iorder
+);
 
 /***********************************************************************
 * -Procedure pckcls_c ( PCK, close file )
@@ -9746,8 +9726,8 @@ extern void reordl_c(
                 {(SpiceInt outlen, SpiceChar out[MESSAGELEN])};
 
 extern void repml_c(
-        ConstSpiceDouble *CONST_STRING,
-        ConstSpiceDouble *CONST_STRING,
+        ConstSpiceChar   *CONST_STRING,
+        ConstSpiceChar   *CONST_STRING,
         SpiceBoolean     value,
         SpiceChar        IN_STRING,
         SpiceInt         outlen, SpiceChar out[MESSAGELEN]
@@ -11746,7 +11726,9 @@ VECTORIZE_dX_i_dX_i__dMN(twovxf, twovxf_c, 6, 6)
         *p = result;
         *ndim2 = ndim;
     }
+%}
 
+%{
     void my_vprojg_nomalloc(
         ConstSpiceDouble *a, SpiceInt ndim,
         ConstSpiceDouble *b, SpiceInt ndim1, 

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1833,91 +1833,6 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 %define TYPEMAP_SIZED_ARGOUT(Type, Typecode) // Use to fill in numeric types below!
 
 /*******************************************************
-*  (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
-*  (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1)
-*******************************************************/
-
-%typemap(in)
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
-        (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1]),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1)
-        (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1])
-{
-//      $1_type $1_name, $2_type $2_name, $3_type $3_name
-//     (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
-
-    CREATE_SIZED_INOUT_ARRAY1(Typecode)
-
-    dimsize[0] = 0;
-    $1 = PyArray_DATA(pyarr);
-    $2 = PyArray_DIM(pyarr, 0);
-    $3 = dimsize;
-}
-
-/*******************************************************
-* (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
-* (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1)
-*******************************************************/
-
-%typemap(in)
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
-        (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1]),
-    (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[], SpiceInt *SIZE1)
-        (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1])
-{
-//      $1_type $1_name, $2_type $2_name, $3_type $3_name
-//    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1)
-
-    CREATE_SIZED_INOUT_ARRAY1(Typecode)
-
-    dimsize[0] = 0;
-    $1 = PyArray_DIM(pyarr, 0);
-    $2 = PyArray_DATA(pyarr);
-    $3 = dimsize;
-}
-
-/*******************************************************
- *  (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1)
- *  (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1)
-*******************************************************/
-
-%typemap(in)
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1)
-        (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1]),
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY1[])
-        (PyArrayObject* pyarr=NULL, SpiceInt dimsize[1])
-{
-//      $1_type $1_name, $2_type $2_name, $3_type $3_name
-//     (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1)
-
-    CREATE_SIZED_INOUT_ARRAY1(Typecode)
-
-    dimsize[0] = 0;
-    $1 = PyArray_DIM(pyarr, 0);
-    $2 = dimsize;
-    $3 = PyArray_DATA(pyarr);
-}
-/*******************************************************
- *  (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1)
- *  (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1)
-*******************************************************/
-
-%typemap(in)
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1)
-            (PyArrayObject* pyarr=NULL),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1)
-            (PyArrayObject* pyarr=NULL)
-{
-//      $1_type $1_name, $2_type $2_name, $3_type $3_name
-//     (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1)
-
-    CREATE_SIZED_INOUT_ARRAY1(Typecode)
-
-    $1 = PyArray_DATA(pyarr);
-    $2 = PyArray_DIM(pyarr, 0);
-}
-
-/*******************************************************
  *  (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1)
  *  (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[])
 *******************************************************/
@@ -1930,7 +1845,6 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 {
 //      $1_type $1_name, $2_type $2_name
 //     (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1)
-
     CREATE_SIZED_INOUT_ARRAY1(Typecode)
 
     $1 = PyArray_DIM(pyarr, 0);
@@ -1950,7 +1864,6 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 {
 //      $1_type $1_name
 //     (Type *SIZED_INOUT_ARRAY1)
-
     CREATE_SIZED_INOUT_ARRAY1(Typecode)
     $1 = PyArray_DATA(pyarr);
 }
@@ -1961,7 +1874,6 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 {
 //      $1_type $1_name
 //      (Type *SIZED_INOUT_ARRAY2[ANY])
-
     CREATE_SIZED_INOUT_ARRAY2(Typecode, $1_dim0)
     $1 = PyArray_DATA(pyarr);
 }
@@ -1972,9 +1884,25 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 {
 //      $1_type $1_name
 //      (Type SIZED_INOUT_ARRAY2[][ANY])
-
     CREATE_SIZED_INOUT_ARRAY2(Typecode, $1_dim1)
     $1 = PyArray_DATA(pyarr);
+}
+
+%typemap(in)
+    (Type SIZED_INOUT_ARRAY2[][])
+            (PyArrayObject* pyarr=NULL)
+{
+//      $1_type $1_name
+//      (Type SIZED_INOUT_ARRAY2[][ANY])
+    int size1 = 0, size2 = 0;
+    int ok = PyArg_ParseTuple($input, "ii", &size1, &size2);
+    if (!ok) {
+        handle_bad_type_error("$symname", "tuple of integers");
+        SWIG_fail;
+    }
+    npy_intp dims[] = {max(size1, 0), max(size2, 0)};                      // ARRAY
+    pyarr = (PyArrayObject *) PyArray_SimpleNew(2, &dims, Typecode);
+    TEST_MALLOC_FAILURE(pyarr);
 }
 
 %typemap(in)
@@ -1991,20 +1919,16 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     $3 = PyArray_DATA(pyarr);
 }
 
-
-// These are the typemaps that resize the output of a 1-dimensional array
+// These are the typemaps that don't resize the output.
 %typemap(argout)
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1),
-    (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1, SpiceInt *SIZE1),
-    (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[], SpiceInt *SIZE1),
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1),
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY1[]),
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1)
+    (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1),
+    (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[]),
+    (Type *SIZED_INOUT_ARRAY1),
+    (Type SIZED_INOUT_ARRAY1[]),
+    (Type *SIZED_INOUT_ARRAY2[ANY]),
+    (Type SIZED_INOUT_ARRAY2[][ANY]),
+    (Type SIZED_INOUT_ARRAY2[][])
 {
-    npy_intp new_dim[1] = { dimsize$argnum[0] };
-    HANDLE_RESIZE(pyarr$argnum, new_dim)
     $result = SWIG_Python_AppendOutput($result, (PyObject *)pyarr$argnum);
     pyarr$argnum = NULL;
 }
@@ -2012,7 +1936,6 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 // These are the typemaps that resize the output of a 2-dimensional array
 %typemap(argout)
      (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY2[][ANY])
-
 {
     npy_intp new_dim[2] = { dimsize$argnum[0], dimsize$argnum[1]};
     HANDLE_RESIZE(pyarr$argnum, new_dim)
@@ -2020,37 +1943,14 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     pyarr$argnum = NULL;
 }
 
-// These are the typemaps that don't resize the output.
-%typemap(argout)
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1),
+%typemap(freearg)
     (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1),
     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[]),
     (Type *SIZED_INOUT_ARRAY1),
     (Type SIZED_INOUT_ARRAY1[]),
     (Type *SIZED_INOUT_ARRAY2[ANY]),
-    (Type SIZED_INOUT_ARRAY2[][ANY])
-{
-    $result = SWIG_Python_AppendOutput($result, (PyObject *)pyarr$argnum);
-    pyarr$argnum = NULL;
-}
-
-%typemap(freearg)
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1),
-    (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1, SpiceInt *SIZE1),
-    (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[], SpiceInt *SIZE1),
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY1),
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY1[]),
-    (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1),
-    (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1),
-    (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1),
-    (SpiceInt DIM1, Type SIZED_INOUT_ARRAY1[]),
-    (Type *SIZED_INOUT_ARRAY1),
-    (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY2[ANY]),
-    (SpiceInt DIM1, Type SIZED_INOUT_ARRAY2[][ANY]),
-    (Type *SIZED_INOUT_ARRAY2[ANY]),
     (Type SIZED_INOUT_ARRAY2[][ANY]),
+    (Type SIZED_INOUT_ARRAY2[][]),
     (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY2[][ANY])
 %{
     Py_XDECREF(pyarr$argnum);

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1978,14 +1978,11 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 }
 
 %typemap(in)
-     (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY2[ANY])
-             (PyArrayObject* pyarr=NULL, SpiceInt dimsize[2]),
      (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY2[][ANY])
              (PyArrayObject* pyarr=NULL, SpiceInt dimsize[2])
 {
 //      $1_type $1_name, $2_type $2_name, $3_type $3_name
 //     (Type *SIZED_INOUT_ARRAY2[ANY])
-
     dimsize[0] = 0;
     dimsize[1] = $3_dim1;
     CREATE_SIZED_INOUT_ARRAY2(Typecode, $3_dim0$3_dim1)
@@ -2014,8 +2011,8 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 
 // These are the typemaps that resize the output of a 2-dimensional array
 %typemap(argout)
-     (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY2[ANY]),
      (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY2[][ANY])
+
 {
     npy_intp new_dim[2] = { dimsize$argnum[0], dimsize$argnum[1]};
     HANDLE_RESIZE(pyarr$argnum, new_dim)
@@ -2038,7 +2035,7 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     pyarr$argnum = NULL;
 }
 
-%typemap(free)
+%typemap(freearg)
     (Type *SIZED_INOUT_ARRAY1, SpiceInt DIM1, SpiceInt *SIZE1),
     (Type SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1),
     (SpiceInt DIM1, Type *SIZED_INOUT_ARRAY1, SpiceInt *SIZE1),
@@ -2054,11 +2051,10 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
     (SpiceInt DIM1, Type SIZED_INOUT_ARRAY2[][ANY]),
     (Type *SIZED_INOUT_ARRAY2[ANY]),
     (Type SIZED_INOUT_ARRAY2[][ANY]),
-    (SpiceInt DIM1, SpiceInt *SIZE1, Type *SIZED_INOUT_ARRAY2[ANY]),
     (SpiceInt DIM1, SpiceInt *SIZE1, Type SIZED_INOUT_ARRAY2[][ANY])
-{
+%{
     Py_XDECREF(pyarr$argnum);
-}
+%}
 
 %enddef
 

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1985,7 +1985,7 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 //     (Type *SIZED_INOUT_ARRAY2[ANY])
     dimsize[0] = 0;
     dimsize[1] = $3_dim1;
-    CREATE_SIZED_INOUT_ARRAY2(Typecode, $3_dim0$3_dim1)
+    CREATE_SIZED_INOUT_ARRAY2(Typecode, $3_dim1)
     $1 = PyArray_DIM(pyarr, 0);
     $2 = &dimsize[0];
     $3 = PyArray_DATA(pyarr);

--- a/swig/make_cspyce2.py
+++ b/swig/make_cspyce2.py
@@ -39,12 +39,6 @@ def new_module(name, doc=None):
 new_module("cspyce.cspyce2")
 new_module("cspyce._cspyce0")
 
-# cspyce1 may call functions in cspyce0, but we need to make them not actually do anything
-import cspyce.cspyce0 as cspyce0
-for name, value in vars(cspyce0).items():
-    if callable(value):
-        vars(cspyce0)[name] = lambda *args: None
-
 import cspyce.cspyce1 as cspyce1
 import keyword
 
@@ -72,6 +66,11 @@ def __copy_attributes_from(function, old_function):
             value = globals()[value.__name__]
         setattr(function, key, value)
 
+"""
+
+
+TRAILER = """
+erract('SET', 'EXCEPTION')
 """
 
 
@@ -113,3 +112,5 @@ def populate_cspyce2(file):
             file.write(f'__copy_attributes_from({name}, cs1.{name})\n')
 
         file.write("\n")
+
+    file.write(TRAILER.lstrip())

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -396,14 +396,12 @@ void return_sigerr(void);
 
 %{
     void outvar_set_from_var_int(SpiceInt in, SpiceInt* out) { *out = in; }
-    void outvar_set_from_var_float(float in, SpiceFloat* out) { *out = in; }
     void outvar_set_from_var_double(SpiceDouble in, SpiceDouble* out) { *out = in; }
     void outvar_set_from_var_char(SpiceChar in, SpiceChar *out) { *out = in; }
     void outvar_set_from_var_bool(SpiceInt in, SpiceBoolean *out) { *out = in; }
 %}
 
 void outvar_set_from_var_int(SpiceInt INPUT, SpiceInt* OUTPUT);
-void outvar_set_from_var_float(float INPUT, SpiceFloat* OUTPUT);
 void outvar_set_from_var_double(SpiceDouble INPUT, SpiceDouble* OUTPUT);
 void outvar_set_from_var_char(SpiceChar INPUT, SpiceChar *OUTPUT);
 void outvar_set_from_var_bool(SpiceInt INPUT, SpiceBoolean *OUTPUT);

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -409,20 +409,24 @@ void outvar_set_from_var_bool(SpiceInt INPUT, SpiceBoolean *OUTPUT);
 %{
     void sized_array_plain(SpiceInt *array) {}
 
-    SpiceInt sized_array_no_resize(SpiceDouble *array, SpiceInt in_size) { return in_size; }
+    SpiceInt sized_array_no_resize(SpiceInt in_size, SpiceDouble *array) { return in_size; }
 
-    SpiceInt sized_array_with_resize(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size, SpiceInt new_size) {
+    SpiceInt sized_array_with_resize(SpiceInt in_size, SpiceInt *out_size, SpiceInt *array, SpiceInt new_size) {
         *out_size = new_size > in_size ? in_size : new_size;
         return in_size;
     }
 
+    void sized_array_2d(SpiceInt *array) { }
 %}
 %apply (SpiceInt SIZED_INOUT_ARRAY1[]) {(SpiceInt *array)};
 void sized_array_plain(SpiceInt SIZED_INOUT_ARRAY1[]);
 
-%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1) {(SpiceInt *array, SpiceInt in_size)};
-SpiceInt sized_array_no_resize(SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1);
+%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1) {(SpiceInt in_size, SpiceInt *array)};
+SpiceInt sized_array_no_resize(SpiceInt DIM1, SpiceInt SIZED_INOUT_ARRAY1[]);
 
-%apply (SpiceInt SIZED_INOUT_ARRAY1[], SpiceInt DIM1, SpiceInt *SIZE1) {(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size)};
-SpiceInt sized_array_with_resize(SpiceInt *array, SpiceInt in_size, SpiceInt *out_size, SpiceInt new_size);
+%apply (SpiceInt DIM1, SpiceInt *SIZE1, SpiceInt SIZED_INOUT_ARRAY2[][ANY])
+        {(SpiceInt in_size, SpiceInt* out_size, SpiceInt array[][3])};
+SpiceInt sized_array_with_resize(SpiceInt in_size, SpiceInt *out_size, SpiceInt array[][3], SpiceInt new_size);
 
+%apply (SpiceInt SIZED_INOUT_ARRAY2[][]) {SpiceInt *array};
+void sized_array_2d(SpiceInt *array);

--- a/unittests/test_build_sanity.py
+++ b/unittests/test_build_sanity.py
@@ -1,3 +1,4 @@
+import os
 import re
 from pathlib import Path
 
@@ -70,10 +71,9 @@ def test_no_SWIG_ConvertPtr(filename):
     # from the generated swig code. This code is generally caused either because
     # swig is generating "wrap" code for a function that it shouldn't be, or because
     # there is a problem with a function's template. We should take a look if this
-    # ever reappears..
-    swig_file_path = Path("swig") / filename
-    if not swig_file_path.exists():
-        swig_file_path = Path("../swig") / filename
+    # ever reappears.
+    root_dir = Path(os.path.realpath(__file__)).parent.parent
+    swig_file_path = root_dir / "swig" / filename
     if not swig_file_path.exists():
         return
 


### PR DESCRIPTION
Removed all my_int_malloc() and replaced them with SIZED_INOUT_ARRAY.

Simplified rewriting of arguments in cspyce1.py

Removed all occurrences of SWIG_ConvertPtr in the generated SWIG code (outside of the fixed headers).  This involved:
1. Fixing numerous typemap errors.
2. Indicating that some code was just code, and not %inline code, so that SWIG wouldn't try to create wrappers for it.
3. Writing a few more typemaps that were a lot simpler than what SWIG was doing.

Overall this now means that any occurrence of SWIG_ConvertPtr in the generated code is an indication of a bug, and a build test has been added to check for this.

The single call to `erract` has been moved to cspyce2.py.  It's appearance in `cspyce1.py` was complicating the generation of cspyce2.py.  Mark approved.