### PR TITLE
Fix test for dskgd

### DIFF
--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -14,7 +14,7 @@
 #define DAFSIZE 125     // size of DAF summary
 #define DASSIZE 256     // DAS size
 #define DLASIZE 8
-#define DSKSIZE 42
+#define DSKSIZE 21      // size in "doubles".  It's 6 integers then 18 doubles
 
 #define CLAUSES 100     // max number of expressions in a SELECT clause
 #define COLLEN 100      // max length of string columns or parsed items

--- a/unittests/test_d.py
+++ b/unittests/test_d.py
@@ -1,3 +1,5 @@
+import struct
+
 import cspyce as cs
 import numpy as np
 import numpy.testing as npt
@@ -867,29 +869,45 @@ def test_dskd02():
     cs.dascls(handle)
 
 
-def fail_dskgd():
+def test_dskgd():
     # open the dsk file
     handle = cs.dasopr(ExtraKernels.phobosDsk)
     # get the dladsc from the file
     dladsc = cs.dlabfs(handle)
     # get dskdsc for target radius
     dskdsc = cs.dskgd(handle, dladsc)
-    # test results
-    assert dskdsc.surfce == 401
-    assert dskdsc.center == 401
-    assert dskdsc.dclass == 1
-    assert dskdsc.dtype == 2
-    assert dskdsc.frmcde == 10021
-    assert dskdsc.corsys == 1
-    npt.assert_almost_equal(dskdsc.corpar, np.zeros(10))
-    assert dskdsc.co1min == pytest.approx(-3.141593)
-    assert dskdsc.co1max == pytest.approx(3.141593)
-    assert dskdsc.co2min == pytest.approx(-1.570796)
-    assert dskdsc.co2max == pytest.approx(1.570796)
-    assert dskdsc.co3min == pytest.approx(8.181895873588292)
-    assert dskdsc.co3max == pytest.approx(13.89340000000111)
-    assert dskdsc.start == pytest.approx(-1577879958.816059)
-    assert dskdsc.stop == pytest.approx(1577880066.183913)
+    # This is the layout of SpiceDSKDscr
+    dtype = np.dtype([('surfce', np.int32),
+                      ('center', np.int32),
+                      ('dclass', np.int32),
+                      ('dtype',  np.int32),
+                      ('frmcde', np.int32),
+                      ('corsys', np.int32),
+                      ('corpar', np.double, 10),
+                      ('co1min', np.double),
+                      ('co1max', np.double),
+                      ('co2min', np.double),
+                      ('co2max', np.double),
+                      ('co3min', np.double),
+                      ('co3max', np.double),
+                      ('start',  np.double),
+                      ('stop',   np.double)])
+    dskdsc = dskdsc.view(dtype)[0]
+    assert dskdsc['surfce'] == 401
+    assert dskdsc['center'] == 401
+    assert dskdsc['dclass'] == 1
+    assert dskdsc['dtype'] == 2
+    assert dskdsc['frmcde'] == 10021
+    assert dskdsc['corsys'] == 1
+    npt.assert_almost_equal(dskdsc['corpar'], np.zeros(10))
+    assert dskdsc['co1min'] == pytest.approx(-3.141593)
+    assert dskdsc['co1max'] == pytest.approx(3.141593)
+    assert dskdsc['co2min'] == pytest.approx(-1.570796)
+    assert dskdsc['co2max'] == pytest.approx(1.570796)
+    assert dskdsc['co3min'] == pytest.approx(8.181895873588292)
+    assert dskdsc['co3max'] == pytest.approx(13.89340000000111)
+    assert dskdsc['start'] == pytest.approx(-1577879958.816059)
+    assert dskdsc['stop'] == pytest.approx(1577880066.183913)
     # cleanup
     cs.dascls(handle)
 


### PR DESCRIPTION
FIXES #78

This test needs to go inside what's supposed to be a black box.  I've unpacked the black box.  If it turns out users really need to see what's inside a SpiceDskDescr, then we may want to rethink this.