### PR TITLE
Fy ellipse

### DIFF
--- a/cspyce/__init__.py
+++ b/cspyce/__init__.py
@@ -137,6 +137,8 @@ except ImportError as err:
         print("Set environment variable 'CSPICE_DEVELOPMENT' to '1' to ignore this error")
         raise err
 
+from cspyce.record_support import Plane, Ellipse
+
 # A set of keywords listing options set globally across the cspyce functions
 GLOBAL_STATUS = set()
 

--- a/cspyce/record_support.py
+++ b/cspyce/record_support.py
@@ -1,5 +1,23 @@
 import numpy as np
 
+"""
+This file supports the special records that are used for SpiceEllipse, SpacePlane,
+SpiceDLADescr, and SpiceDSKDescr.
+
+Ellipses and Planes are created as a subclass of nd.nparray.  They behave exactly like
+numpy arrays, except that there field names can also be accessed directly.  So
+
+      ellipse = ..... method that returns ellipse .....
+      ellipse = ellipse + 1     # Looks like a numpy array
+      print(ellipse.semiMajor)  # Looks like a numpy record
+      
+DLA and DSK descriptors are implemented only as numpy records.  
+       
+       dladescr = .... method that returns a SpiceDLADescr
+       print(dladescr.isize)
+
+"""
+
 DESCRIPTORS = {
     'SpiceDLADescr': np.dtype([
         ("bwdptr", np.int32),
@@ -27,37 +45,94 @@ DESCRIPTORS = {
         ('co3min', np.double),
         ('co3max', np.double),
         ('start',  np.double),
-        ('stop',   np.double)])
+        ('stop',   np.double)]),
 }
 
 
 def create_record(name):
-    """Creates a new uninitialized record whose descriptor has the indicated name."""
-    descriptor = DESCRIPTORS.get(name)
-    if not descriptor:
-        return None
-    array = np.rec.array(None, dtype=descriptor, shape=1)
-    return array[0]
+    """Creates a new zeroed record whose descriptor has the indicated name."""
+    if name in ('SpiceEllipse', 'SpicePlane'):
+        record_type = Ellipse if name == 'SpiceEllipse' else Plane
+        return record_type()
+    else:
+        descriptor = DESCRIPTORS.get(name)
+        if not descriptor:
+            return None
+        array = np.rec.array(None, dtype=descriptor, shape=1)
+        array.fill(0)
+        return array[0]
 
 
 def as_record(name, record):
     """
-    Attempts to convert the record into a record whose descriptor has the indicated name.
+    Attempts to convert the argument into a record whose descriptor has the indicated name.
 
     If the record argument is okay, then it is returned unchanged.  Otherwise we use
     np.rec.array to try and convert it.
     """
-    descriptor = DESCRIPTORS.get(name)
-    if (descriptor is not None and isinstance(record, np.record)
-            and record.dtype == descriptor):
-        return record
-    try:
-        record = np.rec.array(record, descriptor, 1)
-        return record
-    except ValueError:
-        pass
-    # Add more attempts to convert it into a record here.
-    return None
+    if name in ('SpiceEllipse', 'SpicePlane'):
+        record_type = Ellipse if name == 'SpiceEllipse' else Plane
+        return record_type(record)
+    else:
+        descriptor = DESCRIPTORS.get(name)
+        if (descriptor is not None and isinstance(record, np.record)
+                and record.dtype == descriptor):
+            return record
+        try:
+            record = np.rec.array(record, descriptor, 1)
+            return record
+        except ValueError:
+            pass
+        # Add more attempts to convert it into a record here.
+        return None
+
+
+class _HiddenDescriptor(np.ndarray):
+    """
+    The secret subclass of np.ndarray that allows Ellipse and Plane to both be
+    numpy arrays and to have field access.
+    """
+    double_size = np.dtype(np.double).itemsize
+
+    def __new__(cls, descriptor, input_array):
+        if input_array is None:
+            assert descriptor.itemsize % cls.double_size == 0
+            input_array = np.zeros(descriptor.itemsize // cls.double_size,
+                                   dtype=np.double)
+        obj = np.asarray(input_array, dtype=np.double).view(cls)
+        obj._descriptor = descriptor
+        obj._as_record = np.rec.array(obj, dtype=obj._descriptor)[0]
+        return obj
+    
+    def as_record(self):
+        return self._as_record
+
+    def __getattr__(self, item):
+        if item in self._descriptor.names:
+            return self._as_record[item]
+        raise AttributeError
+
+
+class Ellipse(_HiddenDescriptor):
+    descriptor = np.dtype([
+        ('center', np.double, 3),
+        ('semiMajor', np.double, 3),
+        ('semiMinor', np.double, 3),
+    ])
+
+    def __new__(cls, input_array=None):
+        return super().__new__(cls, cls.descriptor, input_array)
+
+
+class Plane(_HiddenDescriptor):
+    descriptor = np.dtype([
+        ('normal', np.double, 3),
+        ('constant', np.double),
+    ])
+
+    def __new__(cls, input_array=None):
+        return super().__new__(cls, cls.descriptor, input_array)
+
 
 ##########################
 #

--- a/unittests/test_transfer_to_emilie.py
+++ b/unittests/test_transfer_to_emilie.py
@@ -5,48 +5,113 @@ from unittests.gettestkernels import ExtraKernels, TEST_FILE_DIR
 from unittests.test_d import cleanup_kernel
 import numpy as np
 
-
-def test_ekdelr():
-    ekpath = os.path.join(TEST_FILE_DIR, "example_ekdelr.ek")
-    cleanup_kernel(ekpath)
-    handle = cs.ekopn(ekpath, ekpath, 0)
-    segno, rcptrs = cs.ekifld(
-        handle,
-        "test_table_ekdelr",
-        10,
-        ["c1"],
-        ["DATATYPE = INTEGER, NULLS_OK = TRUE"],
+"""
+This file contains tests of the build process
+"""
+@pytest.mark.skip
+def test_dskw02_dskrb2_dskmi2():
+    dskpath = os.path.join(TEST_FILE_DIR, "TESTdskw02.dsk")
+    cleanup_kernel(dskpath)
+    # open the dsk file
+    handle = cs.dasopr(ExtraKernels.phobosDsk)
+    # get the dladsc from the file
+    dladsc = cs.dlabfs(handle)
+    # declare some variables
+    finscl = 5.0
+    corscl = 4
+    center = 401
+    surfid = 1
+    dclass = 2
+    frame = "IAU_PHOBOS"
+    first = -50 * cs.jyear()
+    last = 50 * cs.jyear()
+    # stuff from csdsk.h
+    cs_DSK02_MAXVRT = 16000002 // 256  # divide to lower memory usage
+    cs_DSK02_MAXPLT = 2 * (cs_DSK02_MAXVRT - 2)
+    cs_DSK02_MAXVXP = cs_DSK02_MAXPLT // 2
+    cs_DSK02_MAXCEL = 60000000 // 256  # divide to lower memory usage
+    cs_DSK02_MXNVLS = cs_DSK02_MAXCEL + (cs_DSK02_MAXVXP // 2)
+    cs_DSK02_MAXCGR = 100000 // 256  # divide to lower memory usage
+    cs_DSK02_IXIFIX = cs_DSK02_MAXCGR + 7
+    cs_DSK02_MAXNPV = 3 * (cs_DSK02_MAXPLT // 2) + 1
+    cs_DSK02_SPAISZ = (
+        cs_DSK02_IXIFIX
+        + cs_DSK02_MAXVXP
+        + cs_DSK02_MXNVLS
+        + cs_DSK02_MAXVRT
+        + cs_DSK02_MAXNPV
     )
-    cs.ekacli(handle, segno, "c1", [1, 2], [1], [False, False], rcptrs)
-    cs.ekffld(handle, segno, rcptrs)
-    cs.ekdelr(handle, segno, 2)
-    cs.ekcls(handle)
-    cleanup_kernel(ekpath)
-    assert not os.path.exists(ekpath)
+    worksz = cs_DSK02_MAXCEL
+    voxpsz = cs_DSK02_MAXVXP
+    voxlsz = cs_DSK02_MXNVLS
+    spaisz = cs_DSK02_SPAISZ
+    # get verts, number from dskb02 test
+    vrtces = cs.dskv02(handle, dladsc, 1)
+    # get plates, number from dskb02 test
+    plates = cs.dskp02(handle, dladsc, 1)
+    # close the input kernel
+    cs.dskcls(handle, optmiz=True)
+    cs.kclear()
+    # open new dsk file
+    handle = cs.dskopn(dskpath, "TESTdskw02.dsk/AA/29-SEP-2017", 0)
+    # create spatial index
+    spaixd, spaixi = cs.dskmi2(
+        vrtces, plates, finscl, corscl, worksz, voxpsz, voxlsz, False, spaisz)
 
-
-def test_ekfind():
-    cs.use_flags(cs.ekfind)
-    ekpath = os.path.join(TEST_FILE_DIR, "example_ekfind.ek")
-    cleanup_kernel(ekpath)
-    handle = cs.ekopn(ekpath, ekpath, 0)
-    segno, rcptrs = cs.ekifld(
+    # do stuff
+    corsys = 1
+    mncor1 = -cs.pi()
+    mxcor1 = cs.pi()
+    mncor2 = -cs.pi() / 2
+    mxcor2 = cs.pi() / 2
+    # Compute plate model radius bounds.
+    corpar = np.zeros(10)
+    mncor3, mxcor3 = cs.dskrb2(vrtces, plates, corsys, corpar)
+    # Write the segment to the file
+    cs.dskw02(
         handle,
-        "test_table_ekfind",
-        2,
-        ["cc1"],
-        ["DATATYPE = INTEGER, NULLS_OK = TRUE"],
+        center,
+        surfid,
+        dclass,
+        frame,
+        corsys,
+        corpar,
+        mncor1,
+        mxcor1,
+        mncor2,
+        mxcor2,
+        mncor3,
+        mxcor3,
+        first,
+        last,
+        vrtces,
+        plates,
+        spaixd,
+        spaixi,
     )
-    cs.ekacli(handle, segno, "cc1", [1, 2], [
-              1, 1], [False, False], rcptrs)
-    cs.ekffld(handle, segno, rcptrs)
-    cs.ekcls(handle)
+    # Close the dsk file
+    cs.dskcls(handle, optmiz=True)
+    # cleanup
     cs.kclear()
-    cs.furnsh(ekpath)
-    nmrows = cs.ekfind("SELECT CC1 FROM TEST_TABLE_EKFIND WHERE CC1 > 0")
-    assert (
-        nmrows != 0
-    )  # should be 2 but I am not concerned about correctness in this case
-    cs.kclear()
-    cleanup_kernel(ekpath)
-    assert not os.path.exists(ekpath)
+    cleanup_kernel(dskpath)
+
+import cspyce
+import numpy.testing as npt
+from gettestkernels import ExtraKernels
+
+def test_dskv02():
+    # open the dsk file
+    handle = cs.dasopr(ExtraKernels.phobosDsk)
+    # get the dladsc from the file
+    dladsc = cs.dlabfs(handle)
+    # read the vertices
+    vrtces = cs.dskv02(handle, dladsc, 1)
+    npt.assert_almost_equal(
+        vrtces[0],
+        [
+            5.12656957900699912362e-16,
+            -0.00000000000000000000e00,
+            -8.37260000000000026432e00,
+        ],
+    )
+    cs.dascls(handle)

--- a/unittests/test_transfer_to_emilie.py
+++ b/unittests/test_transfer_to_emilie.py
@@ -5,113 +5,48 @@ from unittests.gettestkernels import ExtraKernels, TEST_FILE_DIR
 from unittests.test_d import cleanup_kernel
 import numpy as np
 
-"""
-This file contains tests of the build process
-"""
-@pytest.mark.skip
-def test_dskw02_dskrb2_dskmi2():
-    dskpath = os.path.join(TEST_FILE_DIR, "TESTdskw02.dsk")
-    cleanup_kernel(dskpath)
-    # open the dsk file
-    handle = cs.dasopr(ExtraKernels.phobosDsk)
-    # get the dladsc from the file
-    dladsc = cs.dlabfs(handle)
-    # declare some variables
-    finscl = 5.0
-    corscl = 4
-    center = 401
-    surfid = 1
-    dclass = 2
-    frame = "IAU_PHOBOS"
-    first = -50 * cs.jyear()
-    last = 50 * cs.jyear()
-    # stuff from csdsk.h
-    cs_DSK02_MAXVRT = 16000002 // 256  # divide to lower memory usage
-    cs_DSK02_MAXPLT = 2 * (cs_DSK02_MAXVRT - 2)
-    cs_DSK02_MAXVXP = cs_DSK02_MAXPLT // 2
-    cs_DSK02_MAXCEL = 60000000 // 256  # divide to lower memory usage
-    cs_DSK02_MXNVLS = cs_DSK02_MAXCEL + (cs_DSK02_MAXVXP // 2)
-    cs_DSK02_MAXCGR = 100000 // 256  # divide to lower memory usage
-    cs_DSK02_IXIFIX = cs_DSK02_MAXCGR + 7
-    cs_DSK02_MAXNPV = 3 * (cs_DSK02_MAXPLT // 2) + 1
-    cs_DSK02_SPAISZ = (
-        cs_DSK02_IXIFIX
-        + cs_DSK02_MAXVXP
-        + cs_DSK02_MXNVLS
-        + cs_DSK02_MAXVRT
-        + cs_DSK02_MAXNPV
-    )
-    worksz = cs_DSK02_MAXCEL
-    voxpsz = cs_DSK02_MAXVXP
-    voxlsz = cs_DSK02_MXNVLS
-    spaisz = cs_DSK02_SPAISZ
-    # get verts, number from dskb02 test
-    vrtces = cs.dskv02(handle, dladsc, 1)
-    # get plates, number from dskb02 test
-    plates = cs.dskp02(handle, dladsc, 1)
-    # close the input kernel
-    cs.dskcls(handle, optmiz=True)
-    cs.kclear()
-    # open new dsk file
-    handle = cs.dskopn(dskpath, "TESTdskw02.dsk/AA/29-SEP-2017", 0)
-    # create spatial index
-    spaixd, spaixi = cs.dskmi2(
-        vrtces, plates, finscl, corscl, worksz, voxpsz, voxlsz, False, spaisz)
 
-    # do stuff
-    corsys = 1
-    mncor1 = -cs.pi()
-    mxcor1 = cs.pi()
-    mncor2 = -cs.pi() / 2
-    mxcor2 = cs.pi() / 2
-    # Compute plate model radius bounds.
-    corpar = np.zeros(10)
-    mncor3, mxcor3 = cs.dskrb2(vrtces, plates, corsys, corpar)
-    # Write the segment to the file
-    cs.dskw02(
+def test_ekdelr():
+    ekpath = os.path.join(TEST_FILE_DIR, "example_ekdelr.ek")
+    cleanup_kernel(ekpath)
+    handle = cs.ekopn(ekpath, ekpath, 0)
+    segno, rcptrs = cs.ekifld(
         handle,
-        center,
-        surfid,
-        dclass,
-        frame,
-        corsys,
-        corpar,
-        mncor1,
-        mxcor1,
-        mncor2,
-        mxcor2,
-        mncor3,
-        mxcor3,
-        first,
-        last,
-        vrtces,
-        plates,
-        spaixd,
-        spaixi,
+        "test_table_ekdelr",
+        10,
+        ["c1"],
+        ["DATATYPE = INTEGER, NULLS_OK = TRUE"],
     )
-    # Close the dsk file
-    cs.dskcls(handle, optmiz=True)
-    # cleanup
+    cs.ekacli(handle, segno, "c1", [1, 2], [1], [False, False], rcptrs)
+    cs.ekffld(handle, segno, rcptrs)
+    cs.ekdelr(handle, segno, 2)
+    cs.ekcls(handle)
+    cleanup_kernel(ekpath)
+    assert not os.path.exists(ekpath)
+
+
+def test_ekfind():
+    cs.use_flags(cs.ekfind)
+    ekpath = os.path.join(TEST_FILE_DIR, "example_ekfind.ek")
+    cleanup_kernel(ekpath)
+    handle = cs.ekopn(ekpath, ekpath, 0)
+    segno, rcptrs = cs.ekifld(
+        handle,
+        "test_table_ekfind",
+        2,
+        ["cc1"],
+        ["DATATYPE = INTEGER, NULLS_OK = TRUE"],
+    )
+    cs.ekacli(handle, segno, "cc1", [1, 2], [
+              1, 1], [False, False], rcptrs)
+    cs.ekffld(handle, segno, rcptrs)
+    cs.ekcls(handle)
     cs.kclear()
-    cleanup_kernel(dskpath)
-
-import cspyce
-import numpy.testing as npt
-from gettestkernels import ExtraKernels
-
-def test_dskv02():
-    # open the dsk file
-    handle = cs.dasopr(ExtraKernels.phobosDsk)
-    # get the dladsc from the file
-    dladsc = cs.dlabfs(handle)
-    # read the vertices
-    vrtces = cs.dskv02(handle, dladsc, 1)
-    npt.assert_almost_equal(
-        vrtces[0],
-        [
-            5.12656957900699912362e-16,
-            -0.00000000000000000000e00,
-            -8.37260000000000026432e00,
-        ],
-    )
-    cs.dascls(handle)
+    cs.furnsh(ekpath)
+    nmrows = cs.ekfind("SELECT CC1 FROM TEST_TABLE_EKFIND WHERE CC1 > 0")
+    assert (
+        nmrows != 0
+    )  # should be 2 but I am not concerned about correctness in this case
+    cs.kclear()
+    cleanup_kernel(ekpath)
+    assert not os.path.exists(ekpath)


### PR DESCRIPTION
Unify handling of Ellipse/Plane with handling of the other descriptors.

Ellipses and Planes are now special numpy arrays that act like normal Numpy arrays, but can also have their fields accessed.  They can also turn into records by calling to_record().   On input, accept anything that even looks vaguely like an ellipse or a plane.