### PR TITLE
Make cache dependent on compiler version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -49,6 +49,18 @@ jobs:
         run: |
           python setup.py generate
 
+      - name: Determine compiler version for non-Windows
+        if: matrix.os != 'windows-latest'
+        run: |
+          gcc --version > compiler-version.txt
+          cat compiler-version.txt
+
+      - name: Determine compiler version for Windows
+        if: matrix.os == 'windows-latest'
+        run: |
+          python3 -c 'import distutils.ccompiler as cc; x = cc.new_compiler(); x.initialize(); print(x.cc)' > compiler-version.txt
+          cat compiler-version.txt
+
       - name: Cache libraries
         id: cache-libraries
         uses: actions/cache@v3
@@ -58,7 +70,7 @@ jobs:
           path: build/
           # We need to rebuild the cspice library if the source files have changed,
           # or if there is some change in the build process.
-          key: ${{ matrix.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('setup.py', 'cspice/**/*') }}
+          key: ${{ matrix.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('setup.py', 'compiler-version.txt', 'cspice/**/*') }}
 
       - name: Compile C libraries
         if: ${{ steps.cache-libraries.outputs.cache-hit != 'true' }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Determine compiler version for Windows
         if: matrix.os == 'windows-latest'
+          # We ask Python what it uses as the compiler.  I can't find anything simpler.
         run: |
           python3 -c 'import distutils.ccompiler as cc; x = cc.new_compiler(); x.initialize(); print(x.cc)' > compiler-version.txt
           cat compiler-version.txt
@@ -69,7 +70,8 @@ jobs:
         with:
           path: build/
           # We need to rebuild the cspice library if the source files have changed,
-          # or if there is some change in the build process.
+          # if there is some change in the build process, or if the compiler version
+          # has changed.
           key: ${{ matrix.os }}-${{ runner.arch }}-${{ matrix.python-version }}-${{ env.cache-name }}-${{ hashFiles('setup.py', 'compiler-version.txt', 'cspice/**/*') }}
 
       - name: Compile C libraries


### PR DESCRIPTION
We've had several failures because the cached libraries don't depend on the C compiler.  On windows, the binaries are incompatible.  On Mac, the binaries are put in different locations.   We make the cache depend on a file that depends on the version of the compiler.