### PR TITLE
Fix EKSSUM.  Fix ARM.  String lists are now String tuples.

### DIFF
--- a/cspyce/cspyce1.py
+++ b/cspyce/cspyce1.py
@@ -881,21 +881,6 @@ def orderi(array):
     return cspyce0.orderi(array, len(array))
 
 ################################################################################
-# For functions that return only a list of strings, don't embed the results in
-# an additional layer [].
-################################################################################
-
-def lparse(list_, delim):
-    result = cspyce0.lparse(list_, delim)
-    if len(result) == 1 and isinstance(result[0], list):
-        return result[0]
-
-def lparsm(list_, delims):
-    result = cspyce0.lparsm(list_, delims)
-    if len(result) == 1 and isinstance(result[0], list):
-        return result[0]
-
-################################################################################
 # When a function returns a value and a "found" flag, and the flag is False,
 # the unused return values contain random values. We change these to something
 # sensible.

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -633,7 +633,7 @@ class Test_OUT_STRINGS_SizeFromArg:
     #   "a", "bb", "ccc", "dddd", et.
     def test_out_strings(self):
         result = ts.out_strings(10)
-        (dim1, dim2), [strings] = result
+        (dim1, dim2), strings = result
         assert (50, 256) == (dim1, dim2)  # This is part of the declaration
         assert 10 == len(strings)
         assert "a" == strings[0]
@@ -645,12 +645,12 @@ class Test_INOUT_STRINGS_SizeFromArg:
     # because we could, we wrote a simple sorting program
     def test_basic_test_tuple(self):
         argument = "Four score and thirty years ago".split(' ')
-        result, = ts.sort_strings(argument)
-        assert sorted(argument) == result
+        result = ts.sort_strings(argument)
+        assert tuple(sorted(argument)) == result
 
     def test_okay_to_pass_empty_list(self):
-        result, = ts.sort_strings(())
-        assert [] == result
+        result = ts.sort_strings(())
+        assert result is ()
 
     def test_requires_one_dimensional_array(self):
         argument = np.array([["a", "b", "c", "d"], ["w", "x", "y", "z"]])

--- a/swig/cspyce0_part2.i
+++ b/swig/cspyce0_part2.i
@@ -5489,6 +5489,7 @@ extern void ekrcei_c(
 * handle     I   Handle of EK.
 * segno      I   Number of segment to be summarized.
 * segsum     O   EK segment summary.
+* nrows      O   The number of rows in the segment.
 * ncols      O   The number of columns in the segment.
 * tabnam     O   The name of the table to which the segment belongs.
 * cnames     O   Column names.
@@ -5502,7 +5503,8 @@ extern void ekrcei_c(
 
 %rename (ekssum) my_ekssum_c;
 %apply (void RETURN_VOID) {void my_ekssum_c};
-%apply (SpiceChar    OUT_STRING[ANY], SpiceInt *SIZE1) {(SpiceChar tabnam[NAMELEN], SpiceInt *nrows)};
+%apply (SpiceChar    OUT_STRING[ANY]) {SpiceChar tabnam[NAMELEN]};
+%apply (SpiceInt     *OUTPUT)                     {(SpiceInt  *nrows)};
 %apply (SpiceInt     *OUTPUT)                     {(SpiceInt  *ncols)};
 %apply (SpiceChar    OUT_STRINGS[ANY][ANY], SpiceInt *NSTRINGS) {(SpiceChar cnames[SPICE_EK_MXCLSG][NAMELEN], SpiceInt *n1)};
 %apply (SpiceInt     OUT_ARRAY1[ANY], SpiceInt *SIZE1) {(SpiceInt     cclass[SPICE_EK_MXCLSG], SpiceInt *n2)};
@@ -5516,7 +5518,8 @@ extern void ekrcei_c(
     void my_ekssum_c(
         SpiceInt     handle,
         SpiceInt     segno,
-        SpiceChar    tabnam[NAMELEN], SpiceInt *nrows,
+        SpiceChar    tabnam[NAMELEN],
+        SpiceInt     *nrows,
         SpiceInt     *ncols,
         SpiceChar    cnames[SPICE_EK_MXCLSG][NAMELEN], SpiceInt *n1,
         SpiceInt     cclass[SPICE_EK_MXCLSG], SpiceInt *n2,
@@ -5534,7 +5537,7 @@ extern void ekrcei_c(
         *nrows = segsum.nrows;
         *ncols = segsum.ncols;
 
-        for (int k = 0; k < *nrows; k++) {
+        for (int k = 0; k < *ncols; k++) {
             strncpy(&(cnames[k]), &(segsum.cnames[k]), SPICE_EK_CSTRLN);
             cclass[k] = (SpiceInt) segsum.cdescrs[k].cclass;
             dtype[k]  = (SpiceInt) segsum.cdescrs[k].dtype;

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -690,7 +690,7 @@ get_contiguous_array(int typecode, PyObject *input, int min, int max, int flags)
 
 // result must be a variable which will be Py_DECREF-ed if an error occurs
 %define CONVERT_BUFFER_TO_ARRAY_OF_STRINGS(buffer, rows, columns, result)
-    result = PyList_New(rows);
+    result = PyTuple_New(rows);
     TEST_MALLOC_FAILURE(result);
 
     // Convert the results to Python strings and add them to the list
@@ -702,9 +702,8 @@ get_contiguous_array(int typecode, PyObject *input, int min, int max, int flags)
         }
         PyObject *value = PyUnicode_FromStringAndSize(str, length);
         TEST_MALLOC_FAILURE(value)
-        PyList_SET_ITEM(result, i, value);
+        PyTuple_SET_ITEM(result, i, value);
     }
-    result = Py_BuildValue("[N]", result);  // N steals the reference
 %enddef
 
 %{

--- a/unittests/test_d.py
+++ b/unittests/test_d.py
@@ -1051,7 +1051,7 @@ def test_dskx02():
     raydir = cs.vminus(vertex)
     plid, xpt = cs.dskx02(handle, dladsc, vertex, raydir)
     # test results
-    assert plid == 421
+    assert plid in range(420, 424)   # correct result according to MRS
     npt.assert_almost_equal(xpt, [12.36679999999999957083, 0.0, 0.0])
     # cleanup
     cs.dascls(handle)
@@ -1078,7 +1078,7 @@ def test_dskxsi():
     )
     # check output
     assert handle is not None
-    assert ic[0] == 420
+    assert ic[0] in range(420, 424)  # correct answer according to MRS
     npt.assert_almost_equal(xpt, [12.36679999999999957083, 0.0, 0.0])
 
 

--- a/unittests/test_e.py
+++ b/unittests/test_e.py
@@ -736,8 +736,7 @@ def test_ekopw():
     cleanup_kernel(ekpath)
 
 
-# Fails due to ekifld
-def fail_ekssum():
+def test_ekssum():
     ekpath = os.path.join(TEST_FILE_DIR, "example_ekssum.ek")
     cleanup_kernel(ekpath)
     handle = cs.ekopn(ekpath, ekpath, 0)
@@ -751,14 +750,16 @@ def fail_ekssum():
     cs.ekacli(handle, segno, "c1", [1, 2], [
         1, 1], [False, False], rcptrs)
     cs.ekffld(handle, segno, rcptrs)
-    tabnam, ncols, cnames, cclass, dtype, strln, size, indexd, nullok = cs.ekssum(
+
+    tabnam, nrows, ncols, cnames, cclass, dtype, strln, size, indexd, nullok = cs.ekssum(
         handle, segno)
     assert ncols == 1
-    assert cnames == ["C1"]
+    assert nrows == 2
+    assert cnames == ("C1",)
     assert tabnam == "TEST_TABLE_EKSSUM"
-    assert dtype == 2
-    assert indexd is False
-    # assert c1descr.null == True, for some reason this is actually false, SpikeEKAttDsc may not be working correctly
+    assert dtype[0] == 2
+    assert bool(indexd[0]) is False  # We currently return an int.
+    assert bool(nullok[0]) is True  # Ditto
     cs.ekcls(handle)
     cleanup_kernel(ekpath)
     assert not os.path.exists(ekpath)

--- a/unittests/test_kernels.py
+++ b/unittests/test_kernels.py
@@ -143,11 +143,11 @@ class Test_cspyce1_kernels(unittest.TestCase):
 
     self.assertEqual(list(gipool('ITEST')), [3141,186,282])
     self.assertEqual(list(gdpool('DTEST')), [3.1415,186.282,.0175])
-    self.assertEqual(gcpool('CTEST'), ['LARRY', 'MOE', 'CURLY'])
+    self.assertEqual(list(gcpool('CTEST')), ['LARRY', 'MOE', 'CURLY'])
 
     self.assertEqual(list(gipool('ITEST',1)), [186,282])
     self.assertEqual(list(gdpool('DTEST',1)), [186.282,.0175])
-    self.assertEqual(gcpool('CTEST',1), ['MOE', 'CURLY'])
+    self.assertEqual(list(gcpool('CTEST',1)), ['MOE', 'CURLY'])
 
     self.assertRaises(KeyError, gipool, 'ITESTxxx')
     self.assertRaises(KeyError, gdpool, 'DTESTxxx')

--- a/unittests/test_l.py
+++ b/unittests/test_l.py
@@ -31,17 +31,17 @@ class Test_L(unittest.TestCase):
 
     #### lparse
     x = lparse(" ,bob,   carol,, ted,  alice", ",")
-    self.assertEqual(x, ['', 'bob', 'carol', '', 'ted', 'alice'])
+    self.assertEqual(x, ('', 'bob', 'carol', '', 'ted', 'alice'))
 
     x = lparse("//option1//option2/ //", "/", )
-    self.assertEqual(x, ['', '', 'option1', '', 'option2', '', '', ''])
+    self.assertEqual(x, ('', '', 'option1', '', 'option2', '', '', ''))
 
     #### lparsm
     x = lparsm("Run and find out.", " ")
-    self.assertEqual(x, ['Run', 'and', 'find', 'out.'])
+    self.assertEqual(x, ('Run', 'and', 'find', 'out.'))
 
     x = lparsm("  1986-187// 13:15:12.184 ", " ,/-:")
-    self.assertEqual(x, ['1986', '187', '', '13', '15', '12.184'])
+    self.assertEqual(x, ('1986', '187', '', '13', '15', '12.184'))
 
     #### lstlec
     x = lstlec("EINSTEIN", ["BOHR", "EINSTEIN", "FEYNMAN", "GALILEO", "NEWTON"])

--- a/unittests/test_transfer_to_emilie.py
+++ b/unittests/test_transfer_to_emilie.py
@@ -6,4 +6,3 @@ from unittests.gettestkernels import download_kernels
 """
 Nothing to see here for now
 """
-


### PR DESCRIPTION
FIXES #98
FIXES #95

Fix problems with typemap, code, and test for EKSSUM

Fixed some tests that were failing on ARM64.  Confirmed with NAIF team that the SpiceyPy test we copied was incorrect, and had Mark confirm more accurate results.

Methods that returned [['abc', 'def']] now return ('abc', 'def').  The need for a list inside a list is a SWIG bug that doesn't apply to tuples.  Fixed the tests that relied on the old behavior.