### PR TITLE
Fix memory leak

### DIFF
--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -2487,11 +2487,9 @@ TYPEMAP_INOUT(SpiceDouble,   NPY_DOUBLE)
  }
 
 %typemap(argout)
-    (Type *CONST_STRING),
     (Type IN_STRING) ""
 
 %typemap(freearg)
-    (Type *CONST_STRING),
     (Type IN_STRING) ""
 
 /*******************************************************


### PR DESCRIPTION
Needed to delete two lines that were overwriting previous correct typemap specifications.  Leaking memory on string* arguments.