### PR TITLE
Fix 2nd memory leak

### DIFF
--- a/cspyce/record_support.py
+++ b/cspyce/record_support.py
@@ -1,61 +1,59 @@
+from typing import Optional
 import numpy as np
-
 from cspyce.spice_cell import SpiceCell
 
-DESCRIPTORS = {
-    'SpiceDLADescr': np.dtype([
-        ("bwdptr", np.int32),
-        ("fwdptr", np.int32),
-        ("ibase", np.int32),
-        ("isize", np.int32),
-        ("dbase", np.int32),
-        ("dsize", np.int32),
-        ("cbase", np.int32),
-        ("csize", np.int32),
-    ]),
+PROTOTYPES = {name: np.rec.array(None, fields, 1)
+              for name, fields in [
+                  ('SpiceDLADescr', [
+                      ("bwdptr", np.int32),
+                      ("fwdptr", np.int32),
+                      ("ibase", np.int32),
+                      ("isize", np.int32),
+                      ("dbase", np.int32),
+                      ("dsize", np.int32),
+                      ("cbase", np.int32),
+                      ("csize", np.int32),
+                  ]),
 
-    'SpiceDSKDescr': np.dtype([
-        ('surfce', np.int32),
-        ('center', np.int32),
-        ('dclass', np.int32),
-        ('dtype_', np.int32),  # had to rename from dtype, which is taken.
-        ('frmcde', np.int32),
-        ('corsys', np.int32),
-        ('corpar', np.double, 10),
-        ('co1min', np.double),
-        ('co1max', np.double),
-        ('co2min', np.double),
-        ('co2max', np.double),
-        ('co3min', np.double),
-        ('co3max', np.double),
-        ('start',  np.double),
-        ('stop',   np.double)])
-}
+                  ('SpiceDSKDescr', [
+                      ('surfce', np.int32),
+                      ('center', np.int32),
+                      ('dclass', np.int32),
+                      ('dtype_', np.int32),  # had to rename from dtype, which is taken.
+                      ('frmcde', np.int32),
+                      ('corsys', np.int32),
+                      ('corpar', np.double, 10),
+                      ('co1min', np.double),
+                      ('co1max', np.double),
+                      ('co2min', np.double),
+                      ('co2max', np.double),
+                      ('co3min', np.double),
+                      ('co3max', np.double),
+                      ('start',  np.double),
+                      ('stop',   np.double)])]
+              }
 
-
-def create_record(name):
+def create_record(name: str) -> np.record:
     """Creates a new uninitialized record whose descriptor has the indicated name."""
-    descriptor = DESCRIPTORS.get(name)
-    if not descriptor:
-        return None
-    array = np.rec.array(None, dtype=descriptor, shape=1)
-    return array[0]
+    prototype = PROTOTYPES.get(name)
+    assert prototype is not None
+    return np.zeros_like(prototype)[0]
 
 
-def as_record(name, record):
+def as_record(name: str, record) -> Optional[np.record]:
     """
     Attempts to convert the record into a record whose descriptor has the indicated name.
 
     If the record argument is okay, then it is returned unchanged.  Otherwise we use
     np.rec.array to try and convert it.
     """
-    descriptor = DESCRIPTORS.get(name)
-    if (descriptor is not None and isinstance(record, np.record)
-            and record.dtype == descriptor):
+    prototype = PROTOTYPES.get(name)
+    assert prototype is not None
+    if isinstance(record, np.record) and record.dtype == prototype.dtype:
         return record
     try:
-        record = np.rec.array(record, descriptor, 1)
-        return record
+        result = np.rec.array(record, prototype.dtype, 1)
+        return result[0]
     except ValueError:
         pass
     # Add more attempts to convert it into a record here.
@@ -103,3 +101,4 @@ class _SwigSupport:
         See Py_BuildValue for complete format details.
         """
         print(args)
+

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -2487,11 +2487,9 @@ TYPEMAP_INOUT(SpiceDouble,   NPY_DOUBLE)
  }
 
 %typemap(argout)
-    (Type *CONST_STRING),
     (Type IN_STRING) ""
 
 %typemap(freearg)
-    (Type *CONST_STRING),
     (Type IN_STRING) ""
 
 /*******************************************************


### PR DESCRIPTION
np.rec.array creates memory leaks if not used absolutely correctly. 

Slightly rewrote the way in which records are created, and verified that running the test suite ten times doesn't create any persistent garbage.