### PR TITLE
Fix gfevnt

### DIFF
--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -65,6 +65,18 @@ SpiceInt *my_int_malloc(int count, const char *fname) {
     return result;
 }
 
+SpiceChar *my_char_malloc(int count, const char *fname) {
+    SpiceChar *result = (SpiceChar *) PyMem_Malloc(count * sizeof(SpiceChar));
+    if (!result) {
+        chkin_c(fname);
+        setmsg_c("Failed to allocate memory");
+        sigerr_c("SPICE(MALLOCFAILURE)");
+        chkout_c(fname);
+    }
+
+    return result;
+}
+
 /* Internal routine to compare integers for equality */
 int my_assert_eq(int a, int b, const char *fname, const char *message) {
     if (a != b) {

--- a/swig/cspyce0_part2.i
+++ b/swig/cspyce0_part2.i
@@ -6144,7 +6144,7 @@ extern void gfdist_c(
         gfevnt_c(&gfstep_c, &gfrefn_c, gquant, qnpars,
                  NAMELEN, qpnams, qcpars, qdpars, qipars, qlpars, op,
                  refval, tol, adjust, rpt, &gfrepi_c, &gfrepu_c, &gfrepf_c,
-                 nintvls, SPICEFALSE, NULL, &cnfine, &result);
+                 nintvls, SPICEFALSE, NULL, cnfine, result);
     }
 %}
 
@@ -6239,7 +6239,7 @@ extern void gfdist_c(
         gfsstp_c(step);
         gffove_c(inst, tshape, raydir, target, tframe, abcorr, obsrvr,
                  tol, &gfstep_c, &gfrefn_c, rpt, &gfrepi_c, &gfrepu_c, &gfrepf_c,
-                 SPICEFALSE, NULL, &cnfine, &result);
+                 SPICEFALSE, NULL, cnfine, result);
     }
 %}
 
@@ -6424,7 +6424,7 @@ extern void gfilum_c(
         gfsstp_c(step);
         gfocce_c(occtyp, front, fshape, fframe, back, bshape, bframe, abcorr, obsrvr,
                  tol, &gfstep_c, &gfrefn_c, rpt, &gfrepi_c, &gfrepu_c, &gfrepf_c,
-                 SPICEFALSE, NULL, &cnfine, &result);
+                 SPICEFALSE, NULL, cnfine, result);
     }
 %}
 


### PR DESCRIPTION
Fixes #111

gfevnt is the only cspyce function in which 2 different string arrays must have the same width. 

Write special code to widen the narrower of the two arrays. 