### PR TITLE
Create Pathlike objects

### DIFF
--- a/cspyce/__init__.py
+++ b/cspyce/__init__.py
@@ -137,7 +137,7 @@ except ImportError as err:
         print("Set environment variable 'CSPICE_DEVELOPMENT' to '1' to ignore this error")
         raise err
 
-from cspyce.spice_cell import SPICE_CELL_INT, SPICE_CELL_DOUBLE, SpiceCell
+from cspyce.spice_cell import *
 
 
 # A set of keywords listing options set globally across the cspyce functions

--- a/cspyce/__init__.py
+++ b/cspyce/__init__.py
@@ -137,7 +137,7 @@ except ImportError as err:
         print("Set environment variable 'CSPICE_DEVELOPMENT' to '1' to ignore this error")
         raise err
 
-from cspyce.spice_cell import *
+from cspyce.spice_cell import SpiceCell, SPICE_CELL_INT, SPICE_CELL_DOUBLE
 
 
 # A set of keywords listing options set globally across the cspyce functions

--- a/cspyce/record_support.py
+++ b/cspyce/record_support.py
@@ -1,6 +1,5 @@
 from typing import Optional
 import numpy as np
-from cspyce.spice_cell import SpiceCell
 
 PROTOTYPES = {name: np.rec.array(None, fields, 1)
               for name, fields in [
@@ -58,47 +57,4 @@ def as_record(name: str, record) -> Optional[np.record]:
         pass
     # Add more attempts to convert it into a record here.
     return None
-
-##########################
-#
-# It is simpler to callback from C to Python if everything is grouped as methods in a
-# single class.  Methods can be called using a simple C-string rather than a PyObject*.
-#
-# The location of this class is known by the function initialize_swig_callback() in
-# cspyce_typemaps.i.
-#
-##########################
-
-
-class _SwigSupport:
-    @staticmethod
-    def create_record(name: str):
-        return create_record(name)
-
-    @staticmethod
-    def as_record(name: str, record):
-        return as_record(name, record)
-
-    @staticmethod
-    def create_spice_cell(typeno: str):
-        return SpiceCell.create_spice_cell(typeno)
-
-    @staticmethod
-    def as_spice_cell(typeno, record):
-        return SpiceCell.as_spice_cell(typeno, record)
-
-    @staticmethod
-    def debug(*args):
-        """
-        Useful for debugging or setting a breakpoint in Spice code.
-
-        Typically called with
-           PyObject *result = PyObject_CallMethod(SWIG_SUPPORT_CLASS, "debug", format, args...);
-           Py_XDECREF(result);
-        Format and args might be something like:
-           ...., "issO", 23, "message1", "message2", pyArray
-        where "i" indicates an integer, "s" a c-string, and O a Python object.
-        See Py_BuildValue for complete format details.
-        """
-        print(args)
 

--- a/cspyce/swig_python_callback.py
+++ b/cspyce/swig_python_callback.py
@@ -36,10 +36,6 @@ class _SwigPythonCallback:
         return sc.as_spice_cell(typeno, record)
 
     @staticmethod
-    def convert_filename_to_byte_string(file: Union[str, bytes, os.PathLike]) -> bytes:
-        return os.fsencode(file)
-
-    @staticmethod
     def debug(*args):
         """
         Useful for debugging or setting a breakpoint in Spice code.

--- a/cspyce/swig_python_callback.py
+++ b/cspyce/swig_python_callback.py
@@ -6,7 +6,10 @@
 # The location of this class is known by the function initialize_swig_callback() in
 # cspyce_typemaps.i.
 #
+# DANGER:  This file is loaded in the middle of loading cspyce0.  In order to avoid
+# circular imports, do not include any top-level imports of cspyce.
 ##########################
+
 import os
 from typing import Union
 
@@ -50,4 +53,3 @@ class _SwigPythonCallback:
         See Py_BuildValue for complete format details.
         """
         print(args)
-

--- a/cspyce/swig_python_callback.py
+++ b/cspyce/swig_python_callback.py
@@ -1,0 +1,53 @@
+##########################
+#
+# It is simpler to callback from C to Python if everything is grouped as methods in a
+# single class.  Methods can be called using a simple C-string rather than a PyObject*.
+#
+# The location of this class is known by the function initialize_swig_callback() in
+# cspyce_typemaps.i.
+#
+##########################
+import os
+from typing import Union
+
+
+class _SwigPythonCallback:
+    @staticmethod
+    def create_record(name: str):
+        from cspyce import record_support as rs
+        return rs.create_record(name)
+
+    @staticmethod
+    def as_record(name: str, record):
+        from cspyce import record_support as rs
+        return rs.as_record(name, record)
+
+    @staticmethod
+    def create_spice_cell(typeno: int):
+        from cspyce import SpiceCell as sc
+        return sc.create_spice_cell(typeno)
+
+    @staticmethod
+    def as_spice_cell(typeno: int, record):
+        from cspyce import SpiceCell as sc
+        return sc.as_spice_cell(typeno, record)
+
+    @staticmethod
+    def convert_filename_to_byte_string(file: Union[str, bytes, os.PathLike]) -> bytes:
+        return os.fsencode(file)
+
+    @staticmethod
+    def debug(*args):
+        """
+        Useful for debugging or setting a breakpoint in Spice code.
+
+        Typically called with
+           PyObject *result = PyObject_CallMethod(SWIG_SUPPORT_CLASS, "debug", format, args...);
+           Py_XDECREF(result);
+        Format and args might be something like:
+           ...., "issO", 23, "message1", "message2", pyArray
+        where "i" indicates an integer, "s" a c-string, and O a Python object.
+        See Py_BuildValue for complete format details.
+        """
+        print(args)
+

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -1,11 +1,13 @@
-import pytest
+import os
+from pathlib import Path
 
 import numpy as np
-import cspyce.typemap_samples as ts
-import cspyce.record_support as record_support
 import numpy.testing as npt
+import pytest
 
-from cspyce import SPICE_CELL_DOUBLE, SpiceCell, SPICE_CELL_INT
+import cspyce.record_support as record_support
+import cspyce.typemap_samples as ts
+from cspyce import SPICE_CELL_DOUBLE, SPICE_CELL_INT, SpiceCell
 
 
 def flatten(array):
@@ -811,6 +813,32 @@ class Test_SpiceCell:
         assert t1[-1] == 4
         t1[1], t1[-2] = 20, 30
         assert tuple(t1) == (1, 20, 30, 4)
+
+
+class Test_FileName:
+    def test_string(self):
+        assert ts.decode_filename('a/b/string.txt') == 'a/b/string.txt'
+
+    def test_byte_array(self):
+        assert ts.decode_filename(b'a/b/bytes.bin') =='a/b/bytes.bin'
+
+    def test_Path(self):
+        assert ts.decode_filename(Path("a") / "b" / "filepath") == 'a/b/filepath'
+
+    def test_pathlike(self):
+        class MyPath (os.PathLike):
+            # Implementation of os.PathLike
+            def __fspath__(self):
+                return "a/b/c/MyPath"
+        assert ts.decode_filename(MyPath()) == "a/b/c/MyPath"
+
+    def test_errors(self):
+        with pytest.raises(ValueError):
+            ts.decode_filename(None)
+        with pytest.raises(ValueError):
+            ts.decode_filename(np.pi)
+        with pytest.raises(ValueError):
+            ts.decode_filename(np.zeros(10))
 
 
 

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -814,6 +814,25 @@ class Test_SpiceCell:
         t1[1], t1[-2] = 20, 30
         assert tuple(t1) == (1, 20, 30, 4)
 
+class Test_SpiceCell_Typemap():
+    def test_spice_cell_in(self):
+        cell = SpiceCell((1, 2, 3, 4))
+        # This function sums the items of the integer SpiceCell.
+        assert ts.SpiceCell_in(cell) == 10
+
+    def test_spice_cell_out(self):
+        # This function returns a double SpiceCell with a single element
+        cell = ts.SpiceCell_out(1.0)
+        assert isinstance(cell, SpiceCell)
+        assert list(cell) == [1.0]
+        assert isinstance(cell[0], float)
+
+    def test_spice_cell_in_out(self):
+        cell = SpiceCell((1, 2, 3, 4))
+        # This appends the value to the integer SpiceCell
+        result = ts.SpiceCell_append(cell, 10)
+        assert list(cell) == [1, 2, 3, 4, 10]
+        assert result is cell
 
 class Test_FileName:
     def test_string(self):

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -842,7 +842,8 @@ class Test_FileName:
         assert ts.decode_filename(b'a/b/bytes.bin') =='a/b/bytes.bin'
 
     def test_Path(self):
-        assert ts.decode_filename(Path("a") / "b" / "filepath") == 'a/b/filepath'
+        expected_value = os.sep.join(["a", "b", "filepath"])
+        assert ts.decode_filename(Path("a") / "b" / "filepath") == expected_value
 
     def test_pathlike(self):
         class MyPath (os.PathLike):

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -3368,7 +3368,7 @@ extern void frmnam_c(
 %apply (void RETURN_VOID) {void furnsh_c};
 
 extern void furnsh_c(
-        ConstSpiceChar *CONST_STRING
+        ConstSpiceChar *CONST_FILENAME
 );
 
 /***********************************************************************
@@ -4642,7 +4642,7 @@ VECTORIZE_3d__3d(latsph, latsph_c)
 %apply (void RETURN_VOID) {void ldpool_c};
 
 extern void ldpool_c(
-        ConstSpiceChar *CONST_STRING
+        ConstSpiceChar *CONST_FILENAME
 );
 
 /***********************************************************************

--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -3354,10 +3354,10 @@ TYPEMAP_ARGOUT(PyObject*,    (value$argnum))
 {
 //      $1_type $1_name
 //      $1_type *CONST_FILENAME
-    byte_string = PyObject_CallMethod(
-        SWIG_CALLBACK_CLASS , "convert_filename_to_byte_string", "O", $input);
 
-    if (!byte_string) {
+    // Badly named function converts string/bytes/os.FilePath to bytes.
+    int status = PyUnicode_FSConverter($input, &byte_string);
+    if (status == 0) {
         handle_bad_type_error("$symname", "String, Byte String, or Path");
         SWIG_fail;
     }

--- a/swig/make_cspyce0_info.py
+++ b/swig/make_cspyce0_info.py
@@ -37,11 +37,12 @@ TYPE_INFO = {
 
 # How to interpret a typemap in an extern declaration
 MAP_INFO = {
-    'OUT_BOOLEAN' : ('O', 'SpiceBoolean'),
-    'OUTPUT'      : ('O', ''),
-    'IN_STRING'   : ('I', 'SpiceChar'),
-    'CONST_STRING': ('I', 'ConstSpiceChar'),
-    'IN_ARRAY1'   : ('I', ''),
+    'OUT_BOOLEAN'    : ('O', 'SpiceBoolean'),
+    'OUTPUT'         : ('O', ''),
+    'IN_STRING'      : ('I', 'SpiceChar'),
+    'CONST_STRING'   : ('I', 'ConstSpiceChar'),
+    'IN_ARRAY1'      : ('I', ''),
+    'CONST_FILENAME' : ('I', 'ConstSpiceChar'),
 }
 
 # Argument names that always refer to body codes or body names

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -439,4 +439,15 @@ int ellipse_in(ConstSpiceEllipse *arg);
 %apply (SpiceEllipse* OUTPUT) {SpiceEllipse *arg};
 void ellipse_out(SpiceEllipse *arg);
 
+%{
+    const SpiceChar* decode_filename(const char* filename) {
+       return filename;
+    }
+%}
+
+%apply (ConstSpiceChar *CONST_FILENAME) {const char *filename};
+%apply (SpiceChar *RETURN_STRING) {const SpiceChar* decode_filename};
+
+const SpiceChar* decode_filename(const char *filename);
+
 

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -439,6 +439,34 @@ int ellipse_in(ConstSpiceEllipse *arg);
 %apply (SpiceEllipse* OUTPUT) {SpiceEllipse *arg};
 void ellipse_out(SpiceEllipse *arg);
 
+// SpiceCell
+%{
+    int SpiceCell_in(SpiceCell *arg) {
+        int total = 0;
+        for (int i = 0; i < size_c(arg); ++i) {
+            total += SPICE_CELL_ELEM_I(arg, i);
+        }
+        return total;
+    }
+
+    void SpiceCell_append(SpiceCell *arg, SpiceInt value) {
+        appndi_c(value, arg);
+    }
+
+    void SpiceCell_out(SpiceCell *arg, SpiceDouble value) {
+        appndd_c(value, arg);
+    }
+%}
+
+%apply (SpiceCellInt* INPUT) {SpiceCell *arg};
+int SpiceCell_in(SpiceCell *arg);
+
+%apply (SpiceCellInt* INOUT) {SpiceCell *arg};
+void SpiceCell_append(SpiceCell *arg, SpiceInt value);
+
+%apply (SpiceCellDouble* OUTPUT) {SpiceCell *arg};
+void SpiceCell_out(SpiceCell *arg, SpiceDouble value);
+
 %{
     const SpiceChar* decode_filename(const char* filename) {
        return filename;

--- a/unittests/gettestkernels.py
+++ b/unittests/gettestkernels.py
@@ -28,6 +28,7 @@ import sys
 import tempfile
 import time
 from pathlib import Path
+import pytest
 
 import requests
 from requests import RequestException
@@ -306,3 +307,25 @@ def download_kernels() -> None:
     get_cassini_test_kernels()  # Download Cassini kernels
     get_extra_test_kernels()  # Download any extra test kernels we need
     write_test_meta_kernel()  # Create the meta kernel file for tests
+
+
+_PATHLIKE_FILENAME_VARIANT_FUNCTIONS =  [
+    lambda x: os.fsencode(x),
+    lambda x: os.fsdecode(x),
+    lambda x: x if isinstance(x, os.PathLike) else Path(x),
+]
+
+def checking_pathlike_filename_variants(variable_name: str):
+    """
+    Adding this annotation to a test (and adding the variable itself as an argument to the
+    test) will cause the test to be called three times.  Each time, the variable will be
+    bound to a different function:
+    1) A function that returns its filename argument as a string,
+    2) A function that returns its filename argument as a byte string,
+    3) A function that returns its filename argument as a Path.
+    These are the three "path-like values" defined by Python
+    """
+    def outer(function):
+        return pytest.mark.parametrize(variable_name, _PATHLIKE_FILENAME_VARIANT_FUNCTIONS)(function)
+    return outer
+

--- a/unittests/test_f_j.py
+++ b/unittests/test_f_j.py
@@ -111,10 +111,10 @@ def test_frmnam():
     assert cs.frmnam(13000) == "ITRF93"
 
 
-@checking_pathlike_filename_variants("modifier")
-def test_furnsh(modifier):
+@checking_pathlike_filename_variants("path_type_variant")
+def test_furnsh(path_type_variant):
     kernel = CoreKernels.testMetaKernel
-    cs.furnsh(modifier(kernel))
+    cs.furnsh(path_type_variant(kernel))
     # 4 kernels + the meta kernel = 5
     assert cs.ktotal("ALL") == 5
 

--- a/unittests/test_f_j.py
+++ b/unittests/test_f_j.py
@@ -8,6 +8,7 @@ from gettestkernels import (
     CoreKernels,
     CassiniKernels,
     ExtraKernels,
+    checking_pathlike_filename_variants,
     download_kernels,
     cleanup_core_kernels,
     TEST_FILE_DIR
@@ -110,8 +111,10 @@ def test_frmnam():
     assert cs.frmnam(13000) == "ITRF93"
 
 
-def test_furnsh():
-    cs.furnsh(CoreKernels.testMetaKernel)
+@checking_pathlike_filename_variants("modifier")
+def test_furnsh(modifier):
+    kernel = CoreKernels.testMetaKernel
+    cs.furnsh(modifier(kernel))
     # 4 kernels + the meta kernel = 5
     assert cs.ktotal("ALL") == 5
 

--- a/unittests/test_k_o.py
+++ b/unittests/test_k_o.py
@@ -3,7 +3,6 @@ import numpy as np
 import numpy.testing as npt
 import os
 import pytest
-from pathlib import Path
 
 from gettestkernels import (
     CoreKernels,

--- a/unittests/test_k_o.py
+++ b/unittests/test_k_o.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.testing as npt
 import os
 import pytest
+from pathlib import Path
 
 from gettestkernels import (
     CoreKernels,
@@ -10,7 +11,8 @@ from gettestkernels import (
     ExtraKernels,
     download_kernels,
     cleanup_core_kernels,
-    TEST_FILE_DIR
+    TEST_FILE_DIR,
+    checking_pathlike_filename_variants
 )
 
 
@@ -156,8 +158,8 @@ def test_latsrf():
     assert radii[0] > 9.77
     assert radii[1] > 9.51
 
-
-def test_ldpool():
+@checking_pathlike_filename_variants("modifier")
+def test_ldpool(modifier):
     ldpool_names = [
         "DELTET/DELTA_T_A",
         "DELTET/K",
@@ -203,7 +205,7 @@ def test_ldpool():
             kernelFile.write(line + "\n")
         kernelFile.write("\\begintext\n")
         kernelFile.close()
-    cs.ldpool(kernel)
+    cs.ldpool(modifier(kernel))
     for var, expectLen in zip(ldpool_names, ldpool_lens):
         n, vartype = cs.dtpool(var)
         assert expectLen == n

--- a/unittests/test_k_o.py
+++ b/unittests/test_k_o.py
@@ -157,8 +157,8 @@ def test_latsrf():
     assert radii[0] > 9.77
     assert radii[1] > 9.51
 
-@checking_pathlike_filename_variants("modifier")
-def test_ldpool(modifier):
+@checking_pathlike_filename_variants("path_type_variant")
+def test_ldpool(path_type_variant):
     ldpool_names = [
         "DELTET/DELTA_T_A",
         "DELTET/K",
@@ -204,7 +204,7 @@ def test_ldpool(modifier):
             kernelFile.write(line + "\n")
         kernelFile.write("\\begintext\n")
         kernelFile.close()
-    cs.ldpool(modifier(kernel))
+    cs.ldpool(path_type_variant(kernel))
     for var, expectLen in zip(ldpool_names, ldpool_lens):
         n, vartype = cs.dtpool(var)
         assert expectLen == n


### PR DESCRIPTION
First step towards generic handling of Path-like objects.  As a test, I've made ldpool and furnsh use these.  So they can accept as their file argument: strings, bytes, or Paths.

As part of this, also moved SwigCallbacks into its own file and renamed it.

Also added tests for SpiceCell, and simplified the word that Swig needs to use to access them.

Eventually, I'll need a list of all methods that need to be rewritten.  Or I hope that it'll be simple enough what I've done