### PR TITLE
Final batch of scalar cspyce tests

### DIFF
--- a/unittests/test_a_c.py
+++ b/unittests/test_a_c.py
@@ -14,6 +14,7 @@ from gettestkernels import (
     TEST_FILE_DIR
 )
 
+
 @pytest.fixture(autouse=True)
 def clear_kernel_pool_and_reset():
     cs.kclear()
@@ -190,29 +191,29 @@ def test_bodvcd():
     assert dim == 3
     expected = np.array([6378.140, 6378.140, 6356.755])
     np.testing.assert_array_almost_equal(expected, values, decimal=1)
-    
-    
+
+
 def test_bodvrd():
     cs.furnsh(CoreKernels.testMetaKernel)
     dim, values = 3, cs.bodvrd("EARTH", "RADII")
     assert dim == 3
     expected = np.array([6378.140, 6378.140, 6356.755])
     np.testing.assert_array_almost_equal(expected, values, decimal=1)
-    
-    
+
+
 def test_brcktd():
     assert cs.brcktd(-1.0, 1.0, 10.0) == 1.0
     assert cs.brcktd(29.0, 1.0, 10.0) == 10.0
     assert cs.brcktd(3.0, -10.0, 10.0) == 3.0
     assert cs.brcktd(3.0, -10.0, -1.0) == -1.0
-    
-    
+
+
 def test_brckti():
     assert cs.brckti(-1, 1, 10) == 1
     assert cs.brckti(29, 1, 10) == 10
     assert cs.brckti(3, -10, 10) == 3
     assert cs.brckti(3, -10, -1) == -1
-    
+
 
 def test_bschoc():
     array = ["FEYNMAN", "BOHR", "EINSTEIN", "NEWTON", "GALILEO"]
@@ -222,7 +223,7 @@ def test_bschoc():
     assert cs.bschoc("GALILEO", array, order) == 4
     assert cs.bschoc("Galileo", array, order) == -1
     assert cs.bschoc("OBETHE", array, order) == -1
-    
+
 
 def test_bschoi():
     array = [100, 1, 10, 10000, 1000]
@@ -248,21 +249,21 @@ def test_bsrchd():
     assert cs.bsrchd(-11.0, array) == 0
     assert cs.bsrchd(22.0, array) == 2
     assert cs.bsrchd(751.0, array) == -1
-    
+
 
 def test_bsrchi():
     array = np.array([-11, 0, 22, 750])
     assert cs.bsrchi(-11, array) == 0
     assert cs.bsrchi(22, array) == 2
     assert cs.bsrchi(751, array) == -1
-    
-    
+
+
 def test_ccifrm():
     frcode, frname, center = cs.ccifrm(2, 3000)
     assert frname == "ITRF93"
     assert frcode == 13000
     assert center == 399
-    
+
 
 def test_cgv2el():
     vec1 = [1.0, 1.0, 1.0]
@@ -275,22 +276,22 @@ def test_cgv2el():
     npt.assert_array_almost_equal(expected_center, ellipse[0:3])
     npt.assert_array_almost_equal(expected_s_major, ellipse[3:6])
     npt.assert_array_almost_equal(expected_s_minor, ellipse[6:9])
-    
-    
+
+
 def test_chbder():
     cp = [1.0, 3.0, 0.5, 1.0, 0.5, -1.0, 1.0]
     x2s = [0.5, 3.0]
     dpdxs = cs.chbder(cp, x2s, 1.0, 3)
     npt.assert_array_almost_equal([-0.340878, 0.382716, 4.288066, -1.514403],
                                   dpdxs)
-    
+
 
 def test_chbigr():
     p, itgrlp = cs.chbigr([0.0, 3.75, 0.0, 1.875, 0.0, 0.375], [20.0, 10.0],
                           30.0)
     assert p == pytest.approx(6.0)
     assert itgrlp == pytest.approx(10.0)
-    
+
 
 def test_chbint():
     p, dpdx = cs.chbint([1.0, 3.0, 0.5, 1.0, 0.5, -1.0, 1.0], [0.5, 3.0], 1.0)
@@ -301,8 +302,8 @@ def test_chbint():
 def test_chbval():
     p = cs.chbval([1.0, 3.0, 0.5, 1.0, 0.5, -1.0, 1.0], [0.5, 3.0], 1.0)
     assert p == pytest.approx(-0.340878, abs=1e-6)
-    
-    
+
+
 def test_chkin():
     cs.reset()
     assert cs.trcdep() == 0
@@ -315,8 +316,8 @@ def test_chkin():
     cs.chkout("test")
     assert cs.trcdep() == 0
     cs.reset()
-    
-    
+
+
 def test_chkout():
     cs.reset()
     assert cs.trcdep() == 0
@@ -372,14 +373,15 @@ def test_ckcls():
 def test_ckcov(path_type_variant):
     cs.furnsh(CassiniKernels.cassSclk)
     ckid = cs.ckobj(path_type_variant(CassiniKernels.cassCk))[0]
-    cover = cs.ckcov(path_type_variant(CassiniKernels.cassCk), ckid, False, "INTERVAL", 0.0, "SCLK")
+    cover = cs.ckcov(path_type_variant(CassiniKernels.cassCk),
+                     ckid, False, "INTERVAL", 0.0, "SCLK")
     expected_intervals = [
         [267832537952.000000, 267839247264.000000],
         [267839256480.000000, 267867970464.000000],
         [267868006304.000000, 267876773792.000000],
     ]
     npt.assert_array_equal(cover.as_intervals(), expected_intervals)
-    
+
 
 def test_ckfrot():
     cs.furnsh(CoreKernels.testMetaKernel)
@@ -403,7 +405,7 @@ def test_ckfrot():
     assert ref == 1
 
 
-def fail_ckfxfm():
+def test_ckfxfm():
     cs.furnsh(CoreKernels.testMetaKernel)
     cs.furnsh(CassiniKernels.cassSclk)
     cs.furnsh(CassiniKernels.cassCk)
@@ -417,7 +419,7 @@ def fail_ckfxfm():
     arc = cs.vnorm(av)
     assert ref == 1
     assert arc > 0
-    
+
 
 def test_ckgp():
     cs.reset()
@@ -428,8 +430,9 @@ def test_ckgp():
     cs.furnsh(CassiniKernels.cassFk)
     cs.furnsh(CassiniKernels.cassPck)
     ckid = cs.ckobj(CassiniKernels.cassCk)[0]
-    cover = cs.ckcov(CassiniKernels.cassCk, ckid, False, "INTERVAL", 0.0, "SCLK")
-    
+    cover = cs.ckcov(CassiniKernels.cassCk, ckid,
+                     False, "INTERVAL", 0.0, "SCLK")
+
     cmat, clkout = cs.ckgp(ckid, cover[0], 256, "J2000")
     expected_cmat = [
         [0.5064665782997639365, -0.75794210739897316387, 0.41111478554891744963],
@@ -449,7 +452,8 @@ def test_ckgpav():
     cs.furnsh(CassiniKernels.cassFk)
     cs.furnsh(CassiniKernels.cassPck)
     ckid = cs.ckobj(CassiniKernels.cassCk)[0]
-    cover = cs.ckcov(CassiniKernels.cassCk, ckid, False, "INTERVAL", 0.0, "SCLK")
+    cover = cs.ckcov(CassiniKernels.cassCk, ckid,
+                     False, "INTERVAL", 0.0, "SCLK")
     cmat, avout, clkout = cs.ckgpav(ckid, cover[0], 256, "J2000")
     expected_cmat = [
         [0.5064665782997639365, -0.75794210739897316387, 0.41111478554891744963],
@@ -464,7 +468,7 @@ def test_ckgpav():
     npt.assert_array_almost_equal(cmat, expected_cmat)
     npt.assert_array_almost_equal(avout, expected_avout)
     assert clkout == 267832537952.0
-    
+
 
 def test_ckgr02_cknr02():
     cs.kclear()
@@ -487,7 +491,7 @@ def test_ckgr02_cknr02():
     assert sclkr == pytest.approx(0.001000)
     cs.dafcls(handle)
     cs.kclear()
-    
+
 
 def test_ckgr03_cknr03():
     cs.kclear()
@@ -538,14 +542,14 @@ def test_cklpf(path_type_variant):
     assert os.path.isfile(cklpf)
     cleanup_kernel(cklpf)
     assert not os.path.isfile(cklpf)
-    
-    
+
+
 def test_ckmeta():
     cs.furnsh(CoreKernels.testMetaKernel)
     cs.furnsh(ExtraKernels.voyagerSclk)
     idcode = cs.ckmeta(-32000, "SCLK")
     assert idcode == -32
-    
+
 
 @checking_pathlike_filename_variants("path_type_variant")
 def test_ckobj(path_type_variant):
@@ -553,7 +557,7 @@ def test_ckobj(path_type_variant):
     cs.furnsh(CassiniKernels.cassSclk)
     ids = cs.ckobj(path_type_variant(CassiniKernels.cassCk))
     assert len(ids) == 1
-    
+
 
 @checking_pathlike_filename_variants("path_type_variant")
 def test_ckopn(path_type_variant):
@@ -580,8 +584,8 @@ def test_ckopn(path_type_variant):
     assert os.path.exists(ck1)
     cleanup_kernel(ck1)
     assert not os.path.exists(ck1)
-    
-    
+
+
 def test_ckupf():
     cs.reset()
     handle = cs.cklpf(CassiniKernels.cassCk)
@@ -694,7 +698,7 @@ def fail_ckw02():
     assert end_size != init_size
     cs.kclear()
     cleanup_kernel(ck2)
-    
+
 
 def fail_ckw03():
     ck3 = os.path.join(TEST_FILE_DIR, "type3.bc")
@@ -744,7 +748,7 @@ def fail_ckw03():
     assert end_size != init_size
     cs.kclear()
     cleanup_kernel(ck3)
-    
+
 
 # Test fails.
 def fail_ckw05():
@@ -893,11 +897,11 @@ def fail_ckw05():
     assert clk == pytest.approx(0.5)
     cs.kclear()
     cleanup_kernel(ck5)
-    
-    
+
+
 def test_clight():
     assert cs.clight() == 299792.458
-    
+
 
 def test_clpool():
     cs.pdpool("TEST_VAR", [-666.0])
@@ -907,8 +911,8 @@ def test_clpool():
     cs.clpool()
     with pytest.raises(KeyError):
         cs.gdpool("TEST_VAR", 0)
-        
-        
+
+
 def test_cmprss():
     strings = ["ABC...DE.F...", "...........", ".. ..AB....CD"]
     assert cs.cmprss(".", 2, strings[0]) == "ABC..DE.F.."
@@ -916,14 +920,15 @@ def test_cmprss():
     assert cs.cmprss(".", 1, strings[2]) == ". .AB.CD"
     assert cs.cmprss(".", 3, strings[1]) == "..."
     assert cs.cmprss(".", 1, strings[2]) == ". .AB.CD"
-    assert cs.cmprss(" ", 0, " Embe dde d -sp   a c  es   ") == "Embedded-spaces"
-    
-    
+    assert cs.cmprss(
+        " ", 0, " Embe dde d -sp   a c  es   ") == "Embedded-spaces"
+
+
 def test_cnmfrm():
     ioFrcode, ioFrname = cs.cnmfrm("IO")
     assert ioFrcode == 10023
     assert ioFrname == "IAU_IO"
-    
+
 
 def test_conics():
     cs.furnsh(CoreKernels.testMetaKernel)
@@ -944,7 +949,7 @@ def test_conics():
         -2.01458906615054056388e-03,
     ]
     npt.assert_array_almost_equal(pert, expected_pert, decimal=5)
-    
+
 
 def test_convrt():
     assert cs.convrt(300.0, "statute_miles", "km") == 482.80320
@@ -955,8 +960,8 @@ def test_convrt():
     npt.assert_almost_equal(
         cs.convrt(1, "AU", "km"), 149597870.7, decimal=0
     )
-    
-    
+
+
 def test_cpos():
     string = "BOB, JOHN, TED, AND MARTIN...."
     assert cs.cpos(string, " ,", 0) == 3
@@ -970,8 +975,8 @@ def test_cpos():
     assert cs.cpos(string, " ,", -112) == 3
     assert cs.cpos(string, " ,", -1) == 3
     assert cs.cpos(string, " ,", 1230) == -1
-    
-    
+
+
 def test_cposr():
     string = "BOB, JOHN, TED, AND MARTIN...."
     assert cs.cposr(string, " ,", 29) == 19
@@ -987,7 +992,7 @@ def test_cposr():
     assert cs.cposr(string, " ,", 30) == 19
     assert cs.cposr(string, " ,", -1) == -1
     assert cs.cposr(string, " ,", -10) == -1
-    
+
 
 def test_cvpool():
     # add TEST_VAR_CVPOOL
@@ -1003,7 +1008,7 @@ def test_cvpool():
     assert value[0] == 565.0
     cs.clpool()
     assert updated is True
-    
+
 
 def test_cyllat():
     assert cs.cyllat(1.0, (180.0 * cs.rpd()), -1.0) == [
@@ -1011,13 +1016,13 @@ def test_cyllat():
         np.pi,
         -np.pi / 4,
     ]
-    
-    
+
+
 def test_cylrec():
     npt.assert_array_almost_equal(
         cs.cylrec(0.0, np.radians(33.0), 0.0), [0.0, 0.0, 0.0]
     )
-    
+
 
 def test_cylsph():
     a = np.array(cs.cylsph(1.0, np.deg2rad(180.0), 1.0))

--- a/unittests/test_e.py
+++ b/unittests/test_e.py
@@ -523,7 +523,8 @@ def test_ekifld():
 
 @checking_pathlike_filename_variants("path_type_variant")
 def fail_ekinsr_eknelt_ekpsel_ekrcec_ekrced_ekrcei(path_type_variant):
-    ekpath = path_type_variant(os.path.join(TEST_FILE_DIR, "example_ekmany.ek"))
+    ekpath = path_type_variant(os.path.join(
+        TEST_FILE_DIR, "example_ekmany.ek"))
     tablename = "test_table_ekmany"
     cleanup_kernel(ekpath)
     # Create new EK and new segment with table
@@ -562,7 +563,7 @@ def fail_ekinsr_eknelt_ekpsel_ekrcec_ekrced_ekrcei(path_type_variant):
     assert xtypes[2] == 2
     assert ([0] * 3) == list(xclass)
     assert ('TEST_TABLE_EKMANY',
-            'TEST_TABLE_EKMANY', 
+            'TEST_TABLE_EKMANY',
             'TEST_TABLE_EKMANY') == tabs
     assert ('C1', 'D1', 'I1') == cols
     # Run query to retrieve the row count
@@ -903,7 +904,7 @@ def fail_errint():
 
 def test_errprt():
     assert cs.errprt("GET", "ALL") == ("SHORT, LONG, EXPLAIN, TRACEBACK, "
-                                      "DEFAULT")
+                                       "DEFAULT")
 
 
 def test_esrchc():

--- a/unittests/test_s.py
+++ b/unittests/test_s.py
@@ -574,7 +574,6 @@ def test_spkapp():
     npt.assert_array_almost_equal(state_vec, expected_vec, decimal=6)
     
 
-# Test changed: acc needs to be of size 3, not 6
 def test_spkaps():
     cs.furnsh(CoreKernels.testMetaKernel)
     et = cs.str2et("2000 JAN 1 12:00:00 TDB")
@@ -1270,8 +1269,7 @@ def test_spkw03():
     assert end_size != init_size
     cleanup_kernel(spk3)
     
-
-# Test changed: the array needs to be flattened before 
+ 
 def test_spkw05():
     spk5 = os.path.join(TEST_FILE_DIR, "test5.bsp")
     cleanup_kernel(spk5)
@@ -1312,7 +1310,6 @@ def test_spkw05():
     cleanup_kernel(spk5)
     
 
-# Test changed: discrete_states array needs to be flattened
 def test_spkw08():
     spk8 = os.path.join(TEST_FILE_DIR, "test8.bsp")
     cleanup_kernel(spk8)
@@ -1850,8 +1847,6 @@ def test_srfscc():
     cleanup_kernel(kernel)
     
 
-# Test changed: cspyce.srfxpt() non-vector version does not support iterable
-# 'et' variable.
 def test_srfxpt():
     # load kernels
     cs.furnsh(CoreKernels.testMetaKernel)
@@ -2015,7 +2010,6 @@ def test_subpnt():
         npt.assert_almost_equal(opclat * cs.dpr(), expected[10], decimal=5)
 
 
-# Test changed: cspyce.subpt_error() does not take iterable 'et' arg
 def test_subpt():
     cs.furnsh(CoreKernels.testMetaKernel)
     et = cs.str2et("JAN 1, 2006")
@@ -2108,8 +2102,7 @@ def test_surfnm():
     npt.assert_array_almost_equal(cs.surfnm(1.0, 2.0, 3.0, point),
                                   [0.0, 0.0, 1.0])
     
-    
-# Test changed. cspyce.surfpt() returns [Numpy array, Boolean]
+
 def test_surfpt():
     position = [2.0, 0.0, 0.0]
     u = [-1.0, 0.0, 0.0]
@@ -2117,7 +2110,6 @@ def test_surfpt():
     npt.assert_array_almost_equal(point[0], [1.0, 0.0, 0.0])
     
 
-# Test changed. cspyce.surfpv() returns [Numpy array, Boolean]
 def test_surfpv():
     stvrtx = [2.0, 0.0, 0.0, 0.0, 0.0, 3.0]
     stdir = [-1.0, 0.0, 0.0, 0.0, 0.0, 4.0]

--- a/unittests/test_t_x.py
+++ b/unittests/test_t_x.py
@@ -1,0 +1,256 @@
+import cspyce as cs
+import numpy as np
+import numpy.testing as npt
+import os
+import pytest
+
+from gettestkernels import (
+    CoreKernels,
+    CassiniKernels,
+    ExtraKernels,
+    download_kernels,
+    cleanup_core_kernels,
+    TEST_FILE_DIR,
+    checking_pathlike_filename_variants
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_kernel_pool_and_reset():
+    cs.kclear()
+    cs.reset()
+    # yield for test
+    yield
+    # clear kernel pool again
+    cs.kclear()
+    cs.reset()
+
+
+def cleanup_kernel(path):
+    cs.kclear()
+    cs.reset()
+    if os.path.isfile(path):
+        os.remove(path)  # pragma: no cover
+    pass
+
+
+def setup_module(module):
+    download_kernels()
+    
+
+# Test changed: furnsh() only works on one kernel at a time.
+def test_tangpt():
+    cs.reset()
+    cs.furnsh(CoreKernels.lsk)
+    cs.furnsh(CoreKernels.pck)
+    cs.furnsh(CoreKernels.spk)
+    cs.furnsh(CassiniKernels.satSpk)
+    cs.furnsh(CassiniKernels.cassTourSpk)
+    cs.furnsh(ExtraKernels.earthHighPerPck)
+    cs.furnsh(ExtraKernels.earthStnSpk)
+    locus = "TANGENT POINT"
+    sc = "CASSINI"
+    target = "SATURN"
+    obsrvr = "DSS-14"
+    fixref = "IAU_SATURN"
+    rayfrm = "J2000"
+    et = cs.str2et("2013-FEB-13 11:21:20.213872 (TDB)")
+    raydir, raylt = cs.spkpos(sc, et, rayfrm, "NONE", obsrvr)
+    tanpt, alt, range, srfpt, trgepc, srfvec = cs.tangpt(
+        "ELLIPSOID", target, et, fixref, "NONE", locus, obsrvr, rayfrm, raydir
+    )
+    npt.assert_array_almost_equal(
+        tanpt, [-113646.428171, 213634.489363, -222709.965702], decimal=5
+    )
+    assert alt == pytest.approx(271285.892825)
+    assert range == pytest.approx(1425243487.098913)
+    npt.assert_array_almost_equal(
+        srfpt, [-21455.320586, 40332.076698, -35458.506180], decimal=5
+    )
+    assert trgepc == pytest.approx(414026480.213872)
+    
+    
+def fail_termpt():
+    cs.reset()
+    cs.furnsh(CoreKernels.spk)
+    cs.furnsh(ExtraKernels.marsSpk)
+    cs.furnsh(CoreKernels.pck)
+    cs.furnsh(CoreKernels.lsk)
+    cs.furnsh(ExtraKernels.phobosDsk)
+    # set the time
+    et = cs.str2et("1972 AUG 11 00:00:00")
+    # call limpt
+    npts, points, epochs, tangts = cs.termpt(
+        "UMBRAL/TANGENT/DSK/UNPRIORITIZED",
+        "SUN",
+        "Phobos",
+        et,
+        "IAU_PHOBOS",
+        "CN+S",
+        "CENTER",
+        "MARS",
+        [0.0, 0.0, 1.0],
+        cs.twopi() / 3.0,
+        3,
+        1.0e-4,
+        1.0e-7,
+        10000,
+    )
+    assert points is not None
+    assert len(points) == 3
+    
+
+# Test changed: does not need a lenout parameter
+def test_timdef():
+    LSK = os.path.join(TEST_FILE_DIR, CoreKernels.lsk)
+    cs.furnsh(LSK)
+    # Calendar - default is Gregorian
+    value = cs.timdef("GET", "CALENDAR", "GREGORIAN")
+    assert value == "GREGORIAN" or "JULIAN" or "MIXED"
+    # System - ensure it changes the str2et results
+    assert "UTC" == cs.timdef("GET", "SYSTEM", "UTC")
+    # Approximately 64.184
+    saveET = cs.str2et("2000-01-01T12:00:00")
+    # Change to TDB system
+    assert "TDB" == cs.timdef("SET", "SYSTEM", "TDB")
+    assert 0.0 == cs.str2et("2000-01-01T12:00:00")
+    # Change back to UTC system
+    assert "UTC" == cs.timdef("SET", "SYSTEM", "UTC")
+    assert saveET == cs.str2et("2000-01-01T12:00:00")
+    # Cleanup
+    
+
+# Test changed: tpictr() only has one returned value
+def test_timout():
+    sample = "Thu Oct 1 11:11:11 PDT 1111"
+    cs.furnsh(CoreKernels.testMetaKernel)
+    pic = cs.tpictr(sample)
+    et = 188745364.0
+    out = cs.timout(et, pic)
+    assert out == "Sat Dec 24 18:14:59 PDT 2005"
+    
+    
+def test_tipbod():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    et = cs.str2et("Jan 1 2005")
+    tipm = cs.tipbod("J2000", 699, et)
+    assert tipm is not None
+    
+    
+def test_tisbod():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    et = cs.str2et("Jan 1 2005")
+    tsipm = cs.tisbod("J2000", 699, et)
+    assert tsipm is not None
+    
+    
+def fail_tkfram():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    cs.furnsh(CassiniKernels.cassFk)
+    rotation, nextFrame = cs.tkfram(-82001)
+    expected = np.array(
+        [
+            [6.12323400e-17, 0.00000000e00, -1.00000000e00],
+            [0.00000000e00, 1.00000000e00, -0.00000000e00],
+            [1.00000000e00, 0.00000000e00, 6.12323400e-17],
+        ]
+    )
+    npt.assert_array_almost_equal(rotation, expected)
+    assert nextFrame == -82000
+    
+    
+def test_tkvrsn():
+    version = cs.tkvrsn("toolkit")
+    assert version == "CSPICE_N0067"
+    
+    
+def fail_tparch():
+    cs.tparch("NO")
+    cs.tparch("YES")
+    a, e = cs.tparse("FEB 34, 1993")
+    assert "The day of the month specified for the month of February was 3.40E+01." in e
+    cs.tparch("NO")
+    a, e = cs.tparse("FEB 34, 1993")
+    assert (
+        "The day of the month specified for the month of February was 3.40E+01."
+        not in e
+    )
+# =============================================================================
+# tparch
+# tparse
+# tpictr
+# trace
+# trcdep
+# trcnam
+# trcoff
+# trgsep
+# tsetyr
+# twopi
+# twovec
+# twovxf
+# tyear
+# ucrss
+# unitim
+# unload
+# unorm
+# unormg
+# utc2et
+# vadd
+# vaddg
+# vcrss
+# vdist
+# vdistg
+# vdot
+# vdotg
+# vequ
+# vequg
+# vhat
+# vhatg
+# vlcom
+# vlcom3
+# vlcomg
+# vminug
+# vminus
+# vnorm
+# vnormg
+# vpack
+# vperp
+# vprjp
+# vprjpi
+# vproj
+# vprojg
+# vrel
+# vrelg
+# vrotv
+# vscl
+# vsclg
+# vsep
+# vsepg
+# vsub
+# vsubg
+# vtmv
+# vtmvg
+# vupack
+# vzero
+# vzerog
+# wncomd
+# wncond
+# wndifd
+# wnelmd
+# wnexpd
+# wnextd
+# wnfild
+# wnfltd
+# wnincd
+# wninsd
+# wnintd
+# wnreld
+# wnsumd
+# wnunid
+# xf2eul
+# xf2rav
+# xfmsta
+# xpose
+# xpose6
+# xposeg
+# =============================================================================

--- a/unittests/test_t_x.py
+++ b/unittests/test_t_x.py
@@ -10,6 +10,8 @@ from gettestkernels import (
     ExtraKernels,
     download_kernels,
     cleanup_core_kernels,
+    cleanup_cassini_kernels,
+    cleanup_extra_kernels,
     TEST_FILE_DIR,
     checking_pathlike_filename_variants
 )
@@ -36,7 +38,7 @@ def cleanup_kernel(path):
 
 def setup_module(module):
     download_kernels()
-    
+
 
 # Test changed: furnsh() only works on one kernel at a time.
 def test_tangpt():
@@ -68,9 +70,10 @@ def test_tangpt():
         srfpt, [-21455.320586, 40332.076698, -35458.506180], decimal=5
     )
     assert trgepc == pytest.approx(414026480.213872)
-    
-    
-def fail_termpt():
+
+
+# Test changed to check length of subarray of points
+def test_termpt():
     cs.reset()
     cs.furnsh(CoreKernels.spk)
     cs.furnsh(ExtraKernels.marsSpk)
@@ -97,8 +100,8 @@ def fail_termpt():
         10000,
     )
     assert points is not None
-    assert len(points) == 3
-    
+    assert len(points[0]) == 3
+
 
 # Test changed: does not need a lenout parameter
 def test_timdef():
@@ -118,7 +121,7 @@ def test_timdef():
     assert "UTC" == cs.timdef("SET", "SYSTEM", "UTC")
     assert saveET == cs.str2et("2000-01-01T12:00:00")
     # Cleanup
-    
+
 
 # Test changed: tpictr() only has one returned value
 def test_timout():
@@ -128,23 +131,23 @@ def test_timout():
     et = 188745364.0
     out = cs.timout(et, pic)
     assert out == "Sat Dec 24 18:14:59 PDT 2005"
-    
-    
+
+
 def test_tipbod():
     cs.furnsh(CoreKernels.testMetaKernel)
     et = cs.str2et("Jan 1 2005")
     tipm = cs.tipbod("J2000", 699, et)
     assert tipm is not None
-    
-    
+
+
 def test_tisbod():
     cs.furnsh(CoreKernels.testMetaKernel)
     et = cs.str2et("Jan 1 2005")
     tsipm = cs.tisbod("J2000", 699, et)
     assert tsipm is not None
-    
-    
-def fail_tkfram():
+
+
+def test_tkfram():
     cs.furnsh(CoreKernels.testMetaKernel)
     cs.furnsh(CassiniKernels.cassFk)
     rotation, nextFrame = cs.tkfram(-82001)
@@ -154,16 +157,16 @@ def fail_tkfram():
             [0.00000000e00, 1.00000000e00, -0.00000000e00],
             [1.00000000e00, 0.00000000e00, 6.12323400e-17],
         ]
-    )
+    ).T
     npt.assert_array_almost_equal(rotation, expected)
     assert nextFrame == -82000
-    
-    
+
+
 def test_tkvrsn():
     version = cs.tkvrsn("toolkit")
     assert version == "CSPICE_N0067"
-    
-    
+
+
 def fail_tparch():
     cs.tparch("NO")
     cs.tparch("YES")
@@ -175,82 +178,789 @@ def fail_tparch():
         "The day of the month specified for the month of February was 3.40E+01."
         not in e
     )
-# =============================================================================
-# tparch
-# tparse
-# tpictr
-# trace
-# trcdep
-# trcnam
-# trcoff
-# trgsep
-# tsetyr
-# twopi
-# twovec
-# twovxf
-# tyear
-# ucrss
-# unitim
-# unload
-# unorm
-# unormg
-# utc2et
-# vadd
-# vaddg
-# vcrss
-# vdist
-# vdistg
-# vdot
-# vdotg
-# vequ
-# vequg
-# vhat
-# vhatg
-# vlcom
-# vlcom3
-# vlcomg
-# vminug
-# vminus
-# vnorm
-# vnormg
-# vpack
-# vperp
-# vprjp
-# vprjpi
-# vproj
-# vprojg
-# vrel
-# vrelg
-# vrotv
-# vscl
-# vsclg
-# vsep
-# vsepg
-# vsub
-# vsubg
-# vtmv
-# vtmvg
-# vupack
-# vzero
-# vzerog
-# wncomd
-# wncond
-# wndifd
-# wnelmd
-# wnexpd
-# wnextd
-# wnfild
-# wnfltd
-# wnincd
-# wninsd
-# wnintd
-# wnreld
-# wnsumd
-# wnunid
-# xf2eul
-# xf2rav
-# xfmsta
-# xpose
-# xpose6
-# xposeg
-# =============================================================================
+
+
+def test_tparse():
+    actual_one = cs.tparse("1996-12-18T12:28:28")
+    assert actual_one == -95815892.0
+    actual_two = cs.tparse("1 DEC 1997 12:28:29.192")
+    assert actual_two == -65748690.808
+    actual_three = cs.tparse("1997-162::12:18:28.827")
+    assert actual_three == -80696491.173
+
+
+def test_tpictr():
+    testString = "10:23 P.M. PDT January 3, 1993"
+    pictur = cs.tpictr(testString)
+    assert pictur == "AP:MN AMPM PDT Month DD, YYYY ::UTC-7"
+
+
+def test_trace():
+    matrix = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
+    assert cs.trace(matrix) == 3.0
+
+
+def test_trcdep():
+    cs.reset()
+    assert cs.trcdep() == 0
+    cs.chkin("test")
+    assert cs.trcdep() == 1
+    cs.chkin("trcdep")
+    assert cs.trcdep() == 2
+    cs.chkout("trcdep")
+    assert cs.trcdep() == 1
+    cs.chkout("test")
+    assert cs.trcdep() == 0
+    cs.reset()
+
+
+def test_trcnam():
+    cs.reset()
+    assert cs.trcdep() == 0
+    cs.chkin("test")
+    assert cs.trcdep() == 1
+    assert cs.trcnam(0) == "test"
+    cs.chkin("trcnam")
+    assert cs.trcdep() == 2
+    assert cs.trcnam(1) == "trcnam"
+    cs.chkout("trcnam")
+    assert cs.trcdep() == 1
+    cs.chkout("test")
+    assert cs.trcdep() == 0
+    cs.reset()
+
+
+def test_trgsep():
+    cs.furnsh(CoreKernels.lsk)
+    cs.furnsh(CoreKernels.pck)
+    cs.furnsh(CoreKernels.spk)
+    cs.furnsh(ExtraKernels.mro2007sub)
+    et = cs.str2et("2007-JAN-11 11:21:20.213872 (TDB)")
+    frame = ["IAU_MOON", "IAU_EARTH"]
+    targ = ["MOON", "EARTH"]
+    shape = ["POINT", "SPHERE"]
+    pointsep = cs.trgsep(
+        et, targ[0], shape[0], frame[0], targ[1], shape[0], frame[1], "SUN", "LT+S"
+    )
+    sphersep = cs.trgsep(
+        et, targ[0], shape[1], frame[0], targ[1], shape[1], frame[1], "SUN", "LT+S"
+    )
+    assert cs.dpr() * pointsep == pytest.approx(0.15729276)
+    assert cs.dpr() * sphersep == pytest.approx(0.15413221)
+
+
+def test_tsetyr():
+    # Expand 2-digit year to full year, typically 4-digit
+
+    def tmp_getyr4(iy2):
+        return int(cs.etcal(cs.tparse("3/3/{:02}".format(iy2))).split()[0])
+
+    # Find current lower bound on the 100 year interval of expansion,
+    # so it can be restored on exit
+    tsetyr_lowerbound = tmp_getyr4(0)
+    for iy2_test in range(100):
+        tmp_lowerbound = tmp_getyr4(iy2_test)
+        if tmp_lowerbound < tsetyr_lowerbound:
+            tsetyr_lowerbound = tmp_lowerbound
+            break
+    # Run first case with a year not ending in 00
+    tsetyr_y2 = tsetyr_lowerbound % 100
+    tsetyr_y4 = tsetyr_lowerbound + 200 + ((tsetyr_y2 == 0) and 50 or 0)
+    cs.tsetyr(tsetyr_y4)
+    assert tmp_getyr4(tsetyr_y4 % 100) == tsetyr_y4
+    assert tmp_getyr4((tsetyr_y4 - 1) % 100) == (tsetyr_y4 + 99)
+    # Run second case with a year ending in 00
+    tsetyr_y4 -= tsetyr_y4 % 100
+    cs.tsetyr(tsetyr_y4)
+    assert tmp_getyr4(tsetyr_y4 % 100) == tsetyr_y4
+    assert tmp_getyr4((tsetyr_y4 - 1) % 100) == (tsetyr_y4 + 99)
+    # Cleanup:  reset lowerbound to what it was when this routine started
+    tsetyr_y4 = tsetyr_lowerbound
+    cs.tsetyr(tsetyr_y4)
+    assert tmp_getyr4(tsetyr_y4 % 100) == tsetyr_y4
+    assert tmp_getyr4((tsetyr_y4 - 1) % 100) == (tsetyr_y4 + 99)
+    assert not cs.failed()
+    cs.reset()
+
+
+def test_twopi():
+    assert cs.twopi() == np.pi * 2
+
+
+def test_twovec():
+    axdef = [1.0, 0.0, 0.0]
+    plndef = [0.0, -1.0, 0.0]
+    expected = [[1.0, 0.0, 0.0], [0.0, -1.0, 0.0], [0.0, 0.0, -1.0]]
+    npt.assert_array_almost_equal(cs.twovec(axdef, 1, plndef, 2), expected)
+
+
+def test_twovxf():
+    RAJ2K = 90.3991968556
+    DECJ2K = -52.6956610556
+    PMRA = 19.93e-3
+    PMDEC = 23.24e-3
+    cs.furnsh(CoreKernels.lsk)
+    cs.furnsh(ExtraKernels.mro2007sub)
+    cs.furnsh(ExtraKernels.spk430sub)
+    # need bsp and mro bsp
+    et = cs.str2et("2007 SEP 30 00:00:00 TDB")
+    rpmra = cs.convrt(PMRA, "ARCSECONDS", "RADIANS")
+    rpmdec = cs.convrt(PMDEC, "ARCSECONDS", "RADIANS")
+    ra = RAJ2K * cs.rpd() + rpmra * et / cs.jyear()
+    dec = DECJ2K * cs.rpd() + rpmdec * et / cs.jyear()
+    pcano = cs.radrec(1.0, ra, dec)
+    state, lt = cs.spkezr("MRO", et, "J2000", "NONE", "SSB")
+    stcano = cs.stelab(pcano, state[3:])
+    stcano = np.array([*stcano, 0.0, 0.0, 0.0])
+    stsun, lt = cs.spkezr("SUN", et, "J2000", "CN+S", "MRO")
+    xfisc = cs.twovxf(stsun, 3, stcano, 1)
+    state, lt = cs.spkezr("EARTH", et, "J2000", "CN+S", "MRO")
+    sterth = cs.mxvg(xfisc, state)
+    expected = np.array(
+        [-16659764.322, 97343706.915, 106745539.738, 2.691, -10.345, -7.877]
+    )
+    npt.assert_array_almost_equal(np.around(sterth, 3), expected)
+
+
+def test_tyear():
+    assert cs.tyear() == 31556925.9747
+
+
+def test_ucrss():
+    vec1 = np.array([1.0, 2.0, 3.0])
+    vec2 = np.array([6.0, 1.0, 6.0])
+    expected = np.cross(vec1, vec2) / np.linalg.norm(np.cross(vec1, vec2))
+    outvec = cs.ucrss(vec1, vec2)
+    npt.assert_array_almost_equal(expected, outvec)
+
+
+def test_unitim():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    et = cs.str2et("Dec 19 2003")
+    converted_et = cs.unitim(et, "ET", "JED")
+    npt.assert_almost_equal(converted_et, 2452992.5007428653)
+
+
+# Test changed: cspyce can't load lists of kernels in this format
+def test_unload():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    # 4 kernels + the meta kernel = 5
+    assert cs.ktotal("ALL") == 5
+    # Make list of FURNSHed non-meta-kernels
+    kernel_list = []
+    for iKernel in range(cs.ktotal("ALL")):
+        filnam, filtyp, srcnam, handle = cs.kdata(
+            iKernel, "ALL")
+        if filtyp != "META":
+            kernel_list.append(filnam)
+    assert len(kernel_list) > 0
+    # Unload all kernels
+    cs.unload(CoreKernels.testMetaKernel)
+    assert cs.ktotal("ALL") == 0
+    # Test passing the [list of kernels] as an argument to cs.unload
+    for kernel in kernel_list:
+        cs.furnsh(kernel)
+    assert cs.ktotal("ALL") == len(kernel_list)
+    for kernel in kernel_list[1:]:
+        cs.unload(kernel)
+    assert cs.ktotal("ALL") == 1
+    for kernel in kernel_list[:1]:
+        cs.unload(kernel)
+    assert cs.ktotal("ALL") == 0
+
+
+def test_unorm():
+    v1 = np.array([5.0, 12.0, 0.0])
+    expected_vout = np.array([5.0 / 13.0, 12.0 / 13.0, 0.0])
+    expected_vmag = 13.0
+    vout, vmag = cs.unorm(v1)
+    assert vmag == expected_vmag
+    assert np.array_equal(expected_vout, vout)
+
+
+def test_unormg():
+    v1 = np.array([5.0, 12.0])
+    expected_vout = np.array([5.0 / 13.0, 12.0 / 13.0])
+    expected_vmag = 13.0
+    vout, vmag = cs.unormg(v1)
+    assert vmag == expected_vmag
+    assert np.array_equal(expected_vout, vout)
+
+
+def test_utc2et():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    utcstr = "December 1, 2004 15:04:11"
+    output = cs.utc2et(utcstr)
+    assert output == 155185515.1831043
+    # icy utc2et example gives 1.5518552e+08 as output
+
+
+def test_vadd():
+    v1 = [1.0, 2.0, 3.0]
+    v2 = [4.0, 5.0, 6.0]
+    npt.assert_array_almost_equal(cs.vadd(v1, v2), [5.0, 7.0, 9.0])
+
+
+def test_vaddg():
+    v1 = [1.0, 2.0, 3.0]
+    v2 = [4.0, 5.0, 6.0]
+    npt.assert_array_almost_equal(cs.vaddg(v1, v2), [5.0, 7.0, 9.0])
+
+
+def test_vcrss():
+    v1 = np.array([0.0, 1.0, 0.0])
+    v2 = np.array([1.0, 0.0, 0.0])
+    vout = cs.vcrss(v1, v2)
+    expected = np.array([0.0, 0.0, -1.0])
+    assert np.array_equal(vout, expected)
+
+
+def test_vdist():
+    v1 = np.array([2.0, 3.0, 0.0])
+    v2 = np.array([5.0, 7.0, 12.0])
+    assert cs.vdist(v1, v2) == 13.0
+
+
+def test_vdistg():
+    v1 = np.array([2.0, 3.0])
+    v2 = np.array([5.0, 7.0])
+    assert cs.vdistg(v1, v2) == 5.0
+
+
+def test_vdot():
+    v1 = np.array([1.0, 0.0, -2.0])
+    v2 = np.array([2.0, 1.0, -1.0])
+    assert cs.vdot(v1, v2) == 4.0
+
+
+def test_vdotg():
+    v1 = np.array([1.0, 0.0])
+    v2 = np.array([2.0, 1.0])
+    assert cs.vdotg(v1, v2) == 2
+
+
+def test_vequ():
+    v1 = np.ones(3)
+    assert np.array_equal(v1, cs.vequ(v1))
+
+
+def test_vequg():
+    v1 = np.ones(4)
+    assert np.array_equal(v1, cs.vequg(v1))
+
+
+def test_vhat():
+    v1 = np.array([5.0, 12.0, 0.0])
+    expected = np.array([5 / 13.0, 12 / 13.0, 0.0])
+    vout = cs.vhat(v1)
+    assert np.array_equal(vout, expected)
+
+
+def test_vhatg():
+    v1 = np.array([5.0, 12.0, 0.0, 0.0])
+    expected = np.array([5 / 13.0, 12 / 13.0, 0.0, 0.0])
+    vout = cs.vhatg(v1)
+    assert np.array_equal(vout, expected)
+
+
+def test_vlcom():
+    vec1 = [1.0, 1.0, 1.0]
+    vec2 = [2.0, 2.0, 2.0]
+    outvec = cs.vlcom(1.0, vec1, 1.0, vec2)
+    expected = [3.0, 3.0, 3.0]
+    npt.assert_array_almost_equal(outvec, expected)
+
+
+def test_vlcom3():
+    vec1 = [1.0, 1.0, 1.0]
+    vec2 = [2.0, 2.0, 2.0]
+    vec3 = [3.0, 3.0, 3.0]
+    outvec = cs.vlcom3(1.0, vec1, 1.0, vec2, 1.0, vec3)
+    expected = [6.0, 6.0, 6.0]
+    npt.assert_array_almost_equal(outvec, expected)
+
+
+def test_vlcomg():
+    vec1 = [1.0, 1.0]
+    vec2 = [2.0, 2.0]
+    outvec = cs.vlcomg(1.0, vec1, 1.0, vec2)
+    expected = [3.0, 3.0]
+    npt.assert_array_almost_equal(outvec, expected)
+
+
+def test_vminug():
+    v1 = np.array([1.0, -2.0, 4.0, 0.0])
+    expected = np.array([-1.0, 2.0, -4.0, 0.0])
+    assert np.array_equal(cs.vminug(v1), expected)
+
+
+def test_vminus():
+    v1 = np.array([1.0, -2.0, 0.0])
+    expected = np.array([-1.0, 2.0, 0.0])
+    assert np.array_equal(cs.vminus(v1), expected)
+
+
+def test_vnorm():
+    v1 = np.array([1.0e0, 2.0e0, 2.0e0])
+    assert cs.vnorm(v1) == 3.0e0
+
+
+def test_vnormg():
+    v1 = np.array([3.0, 3.0, 3.0, 3.0])
+    assert cs.vnormg(v1) == 6.0
+
+
+def test_vpack():
+    assert np.array_equal(cs.vpack(1.0, 1.0, 1.0), np.ones(3))
+
+
+def test_vperp():
+    v1 = np.array([6.0, 6.0, 6.0])
+    v2 = np.array([2.0, 0.0, 0.0])
+    expected = np.array([0.0, 6.0, 6.0])
+    assert np.array_equal(cs.vperp(v1, v2), expected)
+
+
+def test_vprjp():
+    vec1 = [-5.0, 7.0, 2.2]
+    norm = [0.0, 0.0, 1.0]
+    orig = [0.0, 0.0, 0.0]
+    plane = cs.nvp2pl(norm, orig)
+    proj = cs.vprjp(vec1, plane)
+    expected = [-5.0, 7.0, 0.0]
+    npt.assert_array_almost_equal(proj, expected)
+
+
+# Test changed. result is returned as a [Numpy Array, Boolean]
+def test_vprjpi():
+    norm1 = [0.0, 0.0, 1.0]
+    norm2 = [1.0, 0.0, 1.0]
+    con1 = 1.2
+    con2 = 0.65
+    plane1 = cs.nvc2pl(norm1, con1)
+    plane2 = cs.nvc2pl(norm2, con2)
+    vec = [1.0, 1.0, 0.0]
+    result = cs.vprjpi(vec, plane1, plane2)
+    expected = [1.0, 1.0, -0.35]
+    npt.assert_array_almost_equal(result[0], expected)
+
+
+def test_vproj():
+    v1 = np.array([6.0, 6.0, 6.0])
+    v2 = np.array([2.0, 0.0, 0.0])
+    expected = np.array([6.0, 0.0, 0.0])
+    vout = cs.vproj(v1, v2)
+    assert np.array_equal(expected, vout)
+
+
+def test_vprojg():
+    v1 = np.array([6.0, 6.0, 6.0])
+    v2 = np.array([2.0, 0.0, 0.0])
+    expected = np.array([6.0, 0.0, 0.0])
+    vout = cs.vprojg(v1, v2)
+    assert np.array_equal(expected, vout)
+    v1 = np.array([6.0, 6.0, 6.0, 0.0])
+    v2 = np.array([2.0, 0.0, 0.0, 0.0])
+    expected = np.array([6.0, 0.0, 0.0, 0.0])
+    vout = cs.vprojg(v1, v2)
+    assert np.array_equal(expected, vout)
+
+
+def test_vrel():
+    vec1 = [12.3, -4.32, 76.0]
+    vec2 = [23.0423, -11.99, -0.10]
+    npt.assert_almost_equal(cs.vrel(vec1, vec2), 1.0016370)
+
+
+def test_vrelg():
+    vec1 = [12.3, -4.32, 76.0, 1.87]
+    vec2 = [23.0423, -11.99, -0.10, -99.1]
+    npt.assert_almost_equal(cs.vrelg(vec1, vec2), 1.2408623)
+
+
+def test_vrotv():
+    v = np.array([1.0, 2.0, 3.0])
+    axis = np.array([0.0, 0.0, 1.0])
+    theta = cs.halfpi()
+    vout = cs.vrotv(v, axis, theta)
+    expected = np.array([-2.0, 1.0, 3.0])
+    np.testing.assert_almost_equal(vout, expected, decimal=7)
+
+
+def test_vscl():
+    v1 = np.array([1.0, -2.0, 0.0])
+    expected = np.array([-1.0, 2.0, 0.0])
+    assert np.array_equal(cs.vscl(-1.0, v1), expected)
+
+
+def test_vsclg():
+    v1 = np.array([1.0, 2.0, -3.0, 4.0])
+    expected = np.zeros(4)
+    assert np.array_equal(cs.vsclg(0.0, v1), expected)
+
+
+def test_vsep():
+    v1 = np.array([1.0, 0.0, 0.0])
+    v2 = np.array([0.0, 1.0, 0.0])
+    assert cs.vsep(v1, v2) == np.pi / 2
+
+
+def test_vsepg():
+    v1 = np.array([3.0, 0.0])
+    v2 = np.array([-5.0, 0.0])
+    assert cs.vsepg(v1, v2) == np.pi
+
+
+def test_vsub():
+    v1 = np.array([1.0, 2.0, 3.0])
+    v2 = np.array([4.0, 5.0, 6.0])
+    expected = np.array([-3.0, -3.0, -3.0])
+    assert np.array_equal(cs.vsub(v1, v2), expected)
+
+
+def test_vsubg():
+    v1 = np.array([1.0, 2.0, 3.0, 4.0])
+    v2 = np.array([1.0, 1.0, 1.0, 1.0])
+    expected = np.array([0.0, 1.0, 2.0, 3.0])
+    assert np.array_equal(cs.vsubg(v1, v2), expected)
+
+
+def test_vtmv():
+    v1 = np.array([2.0, 4.0, 6.0])
+    v2 = np.array([1.0, 1.0, 1.0])
+    matrix = np.array([[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    assert cs.vtmv(v1, matrix, v2) == 4.0
+
+
+def test_vtmvg():
+    v1 = np.array([1.0, 2.0, 3.0])
+    v2 = np.array([1.0, 2.0])
+    matrix = np.array([[2.0, 0.0], [1.0, 2.0], [1.0, 1.0]])
+    assert cs.vtmvg(v1, matrix, v2) == 21.0
+
+
+def test_vupack():
+    v1 = np.array([1.0, 2.0, 3.0])
+    expected = [1.0, 2.0, 3.0]
+    assert cs.vupack(v1) == expected
+
+
+def test_vzero():
+    assert cs.vzero(np.zeros(3))
+
+
+def test_vzerog():
+    assert cs.vzerog(np.zeros(5))
+
+
+def test_wncomd():
+    window1 = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    for d in darray:
+        cs.wninsd(d[0], d[1], window1)
+    assert len(window1) / 2 == 3
+    window2 = cs.wncomd(2.0, 20.0, window1)
+    assert len(window2) / 2 == 2
+    assert (window2[0], window2[1]) == (3.0, 7.0)
+    assert (window2[2], window2[3]) == (11.0, 20.0)
+
+
+def test_wncond():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    for d in darray:
+        cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 3
+    window = cs.wncond(2.0, 1.0, window)
+    assert len(window) / 2 == 2
+    assert (window[0], window[1]) == (9.0, 10.0)
+    assert (window[2], window[3]) == (25.0, 26.0)
+
+
+def test_wndifd():
+    window1 = cs.SpiceCell(typeno=1, size=8)
+    window2 = cs.SpiceCell(typeno=1, size=8)
+    darray1 = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    darray2 = [[2.0, 6.0], [8.0, 10.0], [16.0, 18.0]]
+    for d in darray1:
+        window1 = cs.wninsd(d[0], d[1], window1)
+    assert len(window1) / 2 == 3
+    for d in darray2:
+        window2 = cs.wninsd(d[0], d[1], window2)
+    assert len(window2) / 2 == 3
+    window3 = cs.wndifd(window1, window2)
+    assert len(window3) / 2 == 4
+    assert (window3[0],  window3[1]) == (1.0, 2.0)
+    assert (window3[2],  window3[3]) == (7.0, 8.0)
+    assert (window3[4],  window3[5]) == (10.0, 11.0)
+    assert (window3[6],  window3[7]) == (23.0, 27.0)
+
+
+# Test changed. wnelmd outputs [Boolean, SpiceCell]
+def test_wnelmd():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 3
+    array = [0.0, 1.0, 9.0, 13.0, 29.0]
+    expected = [False, True, True, False, False]
+    for a, exp in zip(array, expected):
+        assert cs.wnelmd(a, window) == [exp, window]
+
+
+def test_wnexpd():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0], [29.0, 29.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 4
+    window = cs.wnexpd(2.0, 1.0, window)
+    assert len(window) / 2 == 3
+    assert (window[0],  window[1]) == (-1.0, 4.0)
+    assert (window[2],  window[3]) == (5.0, 12.0)
+    assert (window[4],  window[5]) == (21.0, 30.0)
+
+
+def test_wnextd():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0], [29.0, 29.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 4
+    window = cs.wnextd("L", window)
+    assert len(window) / 2 == 4
+    assert (window[0], window[1]) == (1.0, 1.0)
+    assert (window[2], window[3]) == (7.0, 7.0)
+    assert (window[4], window[5]) == (23.0, 23.0)
+    assert (window[6], window[7]) == (29.0, 29.0)
+
+
+def test_wnfild():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0], [29.0, 29.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 4
+    window = cs.wnfild(3.0, window)
+    assert len(window) / 2 == 3
+    assert (window[0], window[1]) == (1.0, 3.0)
+    assert (window[2], window[3]) == (7.0, 11.0)
+    assert (window[4], window[5]) == (23.0, 29.0)
+
+
+def test_wnfltd():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0], [29.0, 29.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 4
+    window = cs.wnfltd(3.0, window)
+    assert len(window) / 2 == 2
+    assert (window[0], window[1]) == (7.0, 11.0)
+    assert (window[2], window[3]) == (23.0, 27.0)
+
+
+# Test changed. wnincd outputs [Boolean, SpiceCell]
+def test_wnincd():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 3
+    array = [[1.0, 3.0], [9.0, 10.0], [0.0, 2.0], [13.0, 15.0], [29.0, 30.0]]
+    expected = [True, True, False, False, False]
+    for a, exp in zip(array, expected):
+        assert cs.wnincd(a[0], a[1], window) == [exp, window]
+
+
+def test_wninsd():
+    window = cs.SpiceCell(typeno=1, size=8)
+    darray = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    assert len(window) / 2 == 3
+    assert [x for x in window] == [1.0, 3.0, 7.0, 11.0, 23.0, 27.0]
+
+
+def test_wnintd():
+    window1 = cs.SpiceCell(typeno=1, size=8)
+    window2 = cs.SpiceCell(typeno=1, size=8)
+    darray1 = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    darray2 = [[2.0, 6.0], [8.0, 10.0], [16.0, 18.0]]
+    for d in darray1:
+        window1 = cs.wninsd(d[0], d[1], window1)
+    assert len(window1) / 2 == 3
+    for d in darray2:
+        window2 = cs.wninsd(d[0], d[1], window2)
+    assert len(window2) / 2 == 3
+    window3 = cs.wnintd(window1, window2)
+    assert len(window3) / 2 == 2
+    assert (window3[0], window3[1]) == (2.0, 3.0)
+    assert (window3[2], window3[3]) == (8.0, 10.0)
+
+
+def test_wnreld():
+    window1 = cs.SpiceCell(typeno=1, size=8)
+    window2 = cs.SpiceCell(typeno=1, size=8)
+    darray1 = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    darray2 = [[1.0, 2.0], [9.0, 9.0], [24.0, 27.0]]
+    for d in darray1:
+        window1 = cs.wninsd(d[0], d[1], window1)
+    assert len(window1) / 2 == 3
+    for d in darray2:
+        window2 = cs.wninsd(d[0], d[1], window2)
+    assert len(window2) / 2 == 3
+    ops = ["=", "<>", "<=", "<", ">=", ">"]
+    expected = [False, True, False, False, True, True]
+    for op, exp in zip(ops, expected):
+        assert cs.wnreld(window1, op, window2) == exp
+
+
+# Test changed. wnsumd also returns window SpiceCell
+def test_wnsumd():
+    window = cs.SpiceCell(typeno=1, size=12)
+    darray = [
+        [1.0, 3.0],
+        [7.0, 11.0],
+        [18.0, 18.0],
+        [23.0, 27.0],
+        [30.0, 69.0],
+        [72.0, 80.0],
+    ]
+    for d in darray:
+        window = cs.wninsd(d[0], d[1], window)
+    window, meas, avg, stddev, shortest, longest = cs.wnsumd(window)
+    assert meas == 57.0
+    assert avg == 9.5
+    assert np.around(stddev, decimals=6) == 13.413302
+    assert shortest == 4
+    assert longest == 8
+
+
+def test_wnunid():
+    window1 = cs.SpiceCell(typeno=1, size=8)
+    window2 = cs.SpiceCell(typeno=1, size=8)
+    darray1 = [[1.0, 3.0], [7.0, 11.0], [23.0, 27.0]]
+    darray2 = [[2.0, 6.0], [8.0, 10.0], [16.0, 18.0]]
+    for d in darray1:
+        window1 = cs.wninsd(d[0], d[1], window1)
+    assert len(window1) / 2 == 3
+    for d in darray2:
+        window2 = cs.wninsd(d[0], d[1], window2)
+    assert len(window2) / 2 == 3
+    window3 = cs.wnunid(window1, window2)
+    assert len(window3) / 2 == 4
+    assert (window3[0], window3[1]) == (1.0, 6.0)
+    assert (window3[2], window3[3]) == (7.0, 11.0)
+    assert (window3[4], window3[5]) == (16.0, 18.0)
+    assert (window3[6], window3[7]) == (23.0, 27.0)
+
+
+def test_xf2eul():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    et = cs.str2et("Jan 1, 2009")
+    m = cs.sxform("IAU_EARTH", "J2000", et)
+    eulang, unique = cs.xf2eul(m, 3, 1, 3)
+    assert unique
+    expected = [
+        1.571803284049681,
+        0.0008750002978301174,
+        2.9555269829740034,
+        3.5458495690569166e-12,
+        3.080552365717176e-12,
+        -7.292115373266558e-05,
+    ]
+    npt.assert_array_almost_equal(expected, eulang)
+
+
+def test_xf2rav():
+    e = [1.0, 0.0, 0.0]
+    rz = [[0.0, 1.0, 0.0], [-1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]
+    xform = cs.rav2xf(rz, e)
+    rz2, e2 = cs.xf2rav(xform)
+    npt.assert_array_almost_equal(e, e2)
+    npt.assert_array_almost_equal(rz, rz2)
+
+
+def test_xfmsta():
+    cs.furnsh(CoreKernels.testMetaKernel)
+    et = cs.str2et("July 4, 2003 11:00 AM PST")
+    state, lt = cs.spkezr("Mars", et, "J2000", "LT+S", "Earth")
+    expected_lt = 269.6898813661505
+    expected_state = [
+        7.38222353105354905128e07,
+        -2.71279189984722770751e07,
+        -1.87413063014898747206e07,
+        -6.80851334001380692484e00,
+        7.51399612408221173609e00,
+        3.00129849265935222391e00,
+    ]
+    npt.assert_almost_equal(lt, expected_lt)
+    npt.assert_array_almost_equal(state, expected_state)
+    state_lat = cs.xfmsta(state, "rectangular", "latitudinal", " ")
+    expected_lat_state = [
+        8.08509924324866235256e07,
+        -3.52158255331780634112e-01,
+        -2.33928262716770696272e-01,
+        -9.43348972618204761886e00,
+        5.98157681117165682860e-08,
+        1.03575559016377728336e-08,
+    ]
+    npt.assert_array_almost_equal(state_lat, expected_lat_state)
+
+
+def test_xpose():
+    m1 = [[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 6.0, 0.0]]
+    npt.assert_array_almost_equal(
+        cs.xpose(m1), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
+    )
+    npt.assert_array_almost_equal(
+        cs.xpose(np.array(m1)), [[1.0, 0.0, 0.0],
+                                 [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
+    )
+
+
+def test_xpose6():
+    m1 = [
+        [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+        [0.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+        [0.0, 0.0, 12.0, 13.0, 14.0, 15.0],
+        [0.0, 0.0, 0.0, 16.0, 17.0, 18.0],
+        [0.0, 0.0, 0.0, 0.0, 19.0, 20.0],
+        [0.0, 0.0, 0.0, 0.0, 0.0, 21.0],
+    ]
+    mout_expected = np.array(m1).transpose().tolist()
+    npt.assert_array_almost_equal(cs.xpose6(m1), mout_expected)
+
+
+def test_xposeg():
+    m1 = [[1.0, 2.0, 3.0], [0.0, 4.0, 5.0], [0.0, 6.0, 0.0]]
+    npt.assert_array_almost_equal(
+        cs.xposeg(m1), [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]]
+    )
+    npt.assert_array_almost_equal(
+        cs.xposeg(np.array(m1)),
+        [[1.0, 0.0, 0.0], [2.0, 4.0, 6.0], [3.0, 5.0, 0.0]],
+    )
+    m2 = np.random.rand(3, 4)
+    npt.assert_array_almost_equal(cs.xposeg(m2), m2.T)
+
+
+def test_teardown_trcoff():
+    cs.reset()
+    # Initialize stack trace with two values, and test
+    cs.chkin("A")
+    cs.chkin("B")
+    assert 2 == cs.trcdep()
+    assert "B" == cs.trcnam(1)
+    assert "A" == cs.trcnam(0)
+    # Turn off tracing and test
+    cs.trcoff()
+    assert 0 == cs.trcdep()
+    assert "" == cs.qcktrc()
+    # Ensure subsequent checkins are also ignored
+    cs.chkin("C")
+    assert 0 == cs.trcdep()
+    # Cleanup
+    cs.reset()


### PR DESCRIPTION
This pull contains the final set of cspyce scalar unit tests, `test_t_x.py`.

Adjustments still need to be made, including:
- addressing tests set to `fail`
- addressing tests that are not fully compatible with the new `pathlib` feature