### PR TITLE
Tests, error

### DIFF
--- a/cspyce/cspyce1.py
+++ b/cspyce/cspyce1.py
@@ -266,13 +266,13 @@ def gcpool_error(name, start=0):
     with chkin_and_chkout('gcpool_error'):
         (cvals, found) = cspyce0.gcpool(name, start)
         if not found:
-            ok, _count, _nctype = cspyce0.dtpool(name)
+            ok, _, _ = cspyce0.dtpool(name)
             if not ok:
-                    setmsg(f'pool variable "{name}" not found')
-                    sigerr('SPICE(VARIABLENOTFOUND)')
+                setmsg(f'pool variable "{name}" not found')
+                sigerr('SPICE(VARIABLENOTFOUND)')
             return []
 
-        _ok, count, nctype = cspyce0.dtpool(name)
+        _, count, nctype = cspyce0.dtpool(name)
         if nctype != 'C':
             setmsg(f'string information not available; '
                    f'kernel pool variable "{name}" has numeric values')
@@ -719,7 +719,7 @@ def invert_error(m1):
 
 def invert_vector_error(m1):
     inverses = cspyce0.invert_vector(m1)
-    tests = np.all(inverses == 0., (-2,-1))
+    tests = np.all(inverses == 0., (-2, -1))
     if np.any(tests):
         with chkin_and_chkout('invert_error'):
             setmsg('singular matrix encountered; inverse failed')
@@ -739,7 +739,7 @@ def pcpool(name, cvals):
         cspyce0.pcpool(name, cvals)
 
 ################################################################################
-# These wrappers on the comment readers dafec an dasec ensure that the entire
+# These wrappers on the comment readers dafec and dasec ensure that the entire
 # comment field is read. They eliminate the "done" return value.
 ################################################################################
 

--- a/cspyce/cspyce1.py
+++ b/cspyce/cspyce1.py
@@ -8,6 +8,7 @@
 ################################################################################
 import numpy as np
 import textwrap
+from contextlib import contextmanager
 
 from cspyce import cspyce0
 from cspyce.cspyce0 import *
@@ -51,6 +52,15 @@ def _removing_final_arguments(function):
                 CSPYCE_DEFAULTS[name] = CSPYCE_DEFAULTS[name][:count]
     return function
 
+@contextmanager
+def chkin_and_chkout(name):
+    cspyce0.chkin(name)
+    try:
+        yield
+    finally:
+        cspyce0.chkout(name)
+
+
 def erract(op='', action=''):
     """Allow special argument handling:
         erract()            -> erract('GET', '')
@@ -72,8 +82,7 @@ def erract(op='', action=''):
 
     action = action.upper().strip()
     if op == 'SET' and INTERACTIVE and action in ('ABORT', 'DEFAULT'):
-        print('ERROR action "{}" is disabled in interactive mode; '
-              'using "RETURN"'.format(action))
+        print(f'ERROR action "{action}" is disabled in interactive mode; using "RETURN"')
         cspyce0.erract('SET', 'RETURN')
         return 'RETURN'
 
@@ -132,61 +141,54 @@ def errprt(op='', list_=''):
 def bodc2n_error(code):
     (name, found) = cspyce0.bodc2n(code)
     if not found:
-        chkin('bodc2n_error')
-        setmsg('body code {} not found in kernel pool'.format(code))
-        sigerr('SPICE(BODYIDNOTFOUND)')
-        chkout('bodc2n_error')
+        with chkin_and_chkout('bodc2n_error'):
+            setmsg(f'body code {code} not found in kernel pool')
+            sigerr('SPICE(BODYIDNOTFOUND)')
 
     return name
 
 def bodn2c_error(name):
     (code, found) = cspyce0.bodn2c(name)
     if not found:
-        chkin('bodn2c_error')
-        setmsg('body name "{}" not found in kernel pool'.format(name))
-        sigerr('SPICE(BODYNAMENOTFOUND)')
-        chkout('bodn2c_error')
+        with chkin_and_chkout('bodn2c_error'):
+            setmsg(f'body name "{name}" not found in kernel pool')
+            sigerr('SPICE(BODYNAMENOTFOUND)')
 
     return code
 
 def bods2c_error(name):
     (code, found) = cspyce0.bods2c(name)
     if not found:
-        chkin('bods2c_error')
-        setmsg('body name "{}" not found in kernel pool'.format(name))
-        sigerr('SPICE(BODYNAMENOTFOUND)')
-        chkout('bods2c_error')
+        with chkin_and_chkout('bods2c_error'):
+            setmsg(f'body name "{name}" not found in kernel pool')
+            sigerr('SPICE(BODYNAMENOTFOUND)')
 
     return code
 
 def ccifrm_error(frclss, clssid):
     (frcode, frname, center, found) = cspyce0.ccifrm(frclss, clssid)
     if not found:
-        chkin('ccifrm_error')
-        setmsg('unrecognized frame description: class {}; '
-               'class id {}'.format(frclss, clssid))
-        sigerr('SPICE(INVALIDFRAMEDEF)')
-        chkout('ccifrm_error')
+        with chkin_and_chkout('ccifrm_error'):
+            setmsg(f'unrecognized frame description: class {frclss}; class id {clssid}')
+            sigerr('SPICE(INVALIDFRAMEDEF)')
 
     return [frcode, frname, center]
 
 def cidfrm_error(code):
     (frcode, name, found) = cspyce0.cidfrm(code)
     if not found:
-        chkin('cidfrm_error')
-        setmsg('body code {} not found in kernel pool'.format(code))
-        sigerr('SPICE(BODYIDNOTFOUND)')
-        chkout('cidfrm_error')
+        with chkin_and_chkout('cidfrm_error'):
+            setmsg(f'body code {code} not found in kernel pool')
+            sigerr('SPICE(BODYIDNOTFOUND)')
 
     return [frcode, name]
 
 def ckcov_error(ck, idcode, needav, level, tol, timsys):
     coverage = cspyce0.ckcov(ck, idcode, needav, level, tol, timsys)
     if coverage.card == 0:
-        chkin('ckcov_error')
-        setmsg('body code {} not found in C kernel file {}'.format(idcode, ck))
-        sigerr('SPICE(BODYIDNOTFOUND)')
-        chkout('ckcov_error')
+        with chkin_and_chkout('ckcov_error'):
+            setmsg(f'body code {idcode} not found in C kernel file {ck}')
+            sigerr('SPICE(BODYIDNOTFOUND)')
 
     return coverage
 
@@ -199,13 +201,11 @@ def ckgp_error(inst, sclkdp, tol, ref):
         else:
             namestr = ''
 
-        chkin('ckgp_error')
-        setmsg('insufficient C kernel data to evaluate '
-               'instrument/spacecraft {}{} '
-               'at spacecraft clock time {} '
-               'with tolerance {}'.format(inst, namestr, sclkdp, tol))
-        sigerr('SPICE(CKINSUFFDATA)')
-        chkout('ckgp_error')
+        with chkin_and_chkout('ckgp_error'):
+            setmsg(f'insufficient C kernel data to evaluate instrument/spacecraft '
+                   f'{inst}{namestr} at spacecraft clock time {sclkdp} '
+                   f'with tolerance {tol}')
+            sigerr('SPICE(CKINSUFFDATA)')
 
     return [cmat, clkout]
 
@@ -218,288 +218,248 @@ def ckgpav_error(inst, sclkdp, tol, ref):
         else:
             namestr = ''
 
-        chkin('ckgpav_error')
-        setmsg('insufficient C kernel data to evaluate '
-               'instrument/spacecraft {}{} '
-               'at spacecraft clock time {} '
-               'with tolerance {}'.format(inst, namestr, sclkdp, tol))
-        sigerr('SPICE(CKINSUFFDATA)')
-        chkout('ckgpav_error')
+        with chkin_and_chkout('ckgpav_error'):
+            setmsg(f'insufficient C kernel data to evaluate '
+                   f'instrument/spacecraft {inst}{namestr} '
+                   f'at spacecraft clock time {sclkdp} with tolerance {tol}')
+            sigerr('SPICE(CKINSUFFDATA)')
 
     return [cmat, av, clkout]
 
 def cnmfrm_error(cname):
     (frcode, frname, found) = cspyce0.cnmfrm(cname)
     if not found:
-        chkin('cnmfrm_error')
-        setmsg('body name "{}" not found in kernel pool'.format(cname))
-        sigerr('SPICE(BODYNAMENOTFOUND)')
-        chkout('cnmfrm_error')
+        with chkin_and_chkout('cnmfrm_error'):
+            setmsg(f'body name "{cname}" not found in kernel pool')
+            sigerr('SPICE(BODYNAMENOTFOUND)')
 
     return [frcode, frname]
 
 def dtpool_error(name):
     (found, n, vtype) = cspyce0.dtpool(name)
     if not found:
-        chkin('dtpool_error')
-        setmsg('pool variable "{}" not found'.format(name))
-        sigerr('SPICE(VARIABLENOTFOUND)')
-        chkout('dtpool_error')
+        with chkin_and_chkout('dtpool_error'):
+            setmsg(f'pool variable "{name}" not found')
+            sigerr('SPICE(VARIABLENOTFOUND)')
 
     return [n, vtype]
 
 def frinfo_error(frcode):
     (cent, frclss, clssid, found) = cspyce0.frinfo(frcode)
     if not found:
-        chkin('frinfo_error')
-        setmsg('frame code {} not found in kernel pool'.format(frcode))
-        sigerr('SPICE(FRAMEIDNOTFOUND)')
-        chkout('frinfo_error')
+        with chkin_and_chkout('frinfo_error'):
+            setmsg(f'frame code {frcode} not found in kernel pool')
+            sigerr('SPICE(FRAMEIDNOTFOUND)')
 
     return [cent, frclss, clssid]
 
 def frmnam1_error(frcode):  # change of name; frmnam_error is defined below
     frname = cspyce0.frmnam(frcode)
     if frname == '':
-        chkin('frmnam_error')
-        setmsg('frame code {} not found'.format(frcode))
-        sigerr('SPICE(FRAMEIDNOTFOUND)')
-        chkout('frmnam_error')
+        with chkin_and_chkout('frmnam_error'):
+            setmsg(f'frame code {frcode} not found')
+            sigerr('SPICE(FRAMEIDNOTFOUND)')
 
     return frname
 
 def gcpool_error(name, start=0):
-    (cvals, found) = cspyce0.gcpool(name, start)
-    if not found:
-        ok, _count, _nctype = cspyce0.dtpool(name)
-        if not ok:
-            chkin('gcpool_error')
-            setmsg('pool variable "{}" not found'.format(name))
-            sigerr('SPICE(VARIABLENOTFOUND)')
-            chkout('gcpool_error')
+    with chkin_and_chkout('gcpool_error'):
+        (cvals, found) = cspyce0.gcpool(name, start)
+        if not found:
+            ok, _count, _nctype = cspyce0.dtpool(name)
+            if not ok:
+                    setmsg(f'pool variable "{name}" not found')
+                    sigerr('SPICE(VARIABLENOTFOUND)')
             return []
 
-    _ok, count, nctype = cspyce0.dtpool(name)
-    if nctype != 'C':
-        chkin('gcpool_error')
-        setmsg('string information not available; '
-               'kernel pool variable "{}" has numeric values'.format(name))
-        sigerr('SPICE(WRONGDATATYPE)')
-        chkout('gcpool_error')
-        return []
+        _ok, count, nctype = cspyce0.dtpool(name)
+        if nctype != 'C':
+            setmsg(f'string information not available; '
+                   f'kernel pool variable "{name}" has numeric values')
+            sigerr('SPICE(WRONGDATATYPE)')
+            return []
 
-    if start > count:
-        chkin('gcpool_error')
-        setmsg('kernel pool has only {} '
-               'values for variable "{}";'
-               'start index value {} is too large'.format(count, name, start))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('gcpool_error')
-        return []
+        if start > count:
+            setmsg(f'kernel pool has only {count} values for variable "{name}";'
+                   f'start index value {start} is too large')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
+            return []
 
     return cvals
 
 def gdpool_error(name, start=0):
-    (values, found) = cspyce0.gdpool(name, start)
-    if not found:
+    with chkin_and_chkout("gdpool_error"):
+        (values, found) = cspyce0.gdpool(name, start)
+        if not found:
+            (ok, count, nctype) = cspyce0.dtpool(name)
+            if not ok:
+                setmsg(f'pool variable "{name}" not found')
+                sigerr('SPICE(VARIABLENOTFOUND)')
+                return []
+
         (ok, count, nctype) = cspyce0.dtpool(name)
-        if not ok:
-            chkin('gdpool_error')
-            setmsg('pool variable "{}" not found'.format(name))
-            sigerr('SPICE(VARIABLENOTFOUND)')
-            chkout('gdpool_error')
+        if nctype != 'N':
+            setmsg(f'numeric values are not available; '
+                   f'kernel pool variable "{name}" has string values')
+            sigerr('SPICE(WRONGDATATYPE)')
             return []
 
-    (ok, count, nctype) = cspyce0.dtpool(name)
-    if nctype != 'N':
-        chkin('gdpool_error')
-        setmsg('numeric values are not available; '
-               'kernel pool variable "{}" has string values'.format(name))
-        sigerr('SPICE(WRONGDATATYPE)')
-        chkout('gdpool_error')
-        return []
-
-    if start > count:
-        chkin('gdpool_error')
-        setmsg('kernel pool has only {} '
-               'values for variable "{}";'
-               'start index value {} is too large'.format(count, name, start))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('gdpool_error')
-        return []
+        if start > count:
+            setmsg(f'kernel pool has only {count} values for variable "{name}"; '
+                   f'start index value {start} is too large')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
+            return []
 
     return values
 
 def gipool_error(name, start=0):
-    (ivals, found) = cspyce0.gipool(name, start)
-    if not found:
+    with chkin_and_chkout('gipool_error'):
+        (ivals, found) = cspyce0.gipool(name, start)
+        if not found:
+            (ok, count, nctype) = cspyce0.dtpool(name)
+            if not ok:
+                setmsg(f'fpool variable "{name}" not found')
+                sigerr('SPICE(VARIABLENOTFOUND)')
+                return []
+
         (ok, count, nctype) = cspyce0.dtpool(name)
-        if not ok:
-            chkin('gipool_error')
-            setmsg('pool variable "{}" not found'.format(name))
-            sigerr('SPICE(VARIABLENOTFOUND)')
-            chkout('gipool_error')
+        if nctype != 'N':
+            setmsg(f'numeric values are not available; '
+                   f'kernel pool variable "{name}" has string values')
+            sigerr('SPICE(WRONGDATATYPE)')
             return []
 
-    (ok, count, nctype) = cspyce0.dtpool(name)
-    if nctype != 'N':
-        chkin('gipool_error')
-        setmsg('numeric values are not available; '
-               'kernel pool variable "{}" has string values'.format(name))
-        sigerr('SPICE(WRONGDATATYPE)')
-        chkout('gipool_error')
-        return []
-
-    if start > count:
-        chkin('gipool_error')
-        setmsg('kernel pool has only {} '
-               'values for variable "{}";'
-               'start index value {} is too large'.format(count, name, start))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('gipool_error')
-        return []
+        if start > count:
+            setmsg(f'kernel pool has only {count} values for variable "{name}"; '
+                   f'start index value {start} is too large')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
+            return []
 
     return ivals
 
 def gnpool_error(name, start=0):
-    (kvars, found) = cspyce0.gnpool(name, 0)
-    if not found:
-        chkin('gnpool_error')
-        setmsg('no kernel pool variables found matching template "{}"'.format(name))
-        sigerr('SPICE(VARIABLENOTFOUND)')
-        chkout('gnpool_error')
-        return []
+    with chkin_and_chkout('gnpool_error'):
+        (kvars, found) = cspyce0.gnpool(name, 0)
+        if not found:
+            setmsg(f'no kernel pool variables found matching template "{name}"')
+            sigerr('SPICE(VARIABLENOTFOUND)')
+            return []
 
-    if start > len(kvars):
-        setmsg('kernel pool has only {} '
-               'variables matching template "{}";'
-               'start index value {} is too large'.format(len(kvars), name, start))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('gnpool_error')
-        return []
+        if start > len(kvars):
+            setmsg(f'kernel pool has only {len(kvars)} variables matching template "{name}"; '
+                   f'start index value {start} is too large')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
+            return []
 
     return kvars[start:]
 
 def namfrm1_error(frname):  # change of name; namfrm_error is defined below
     frcode = cspyce0.namfrm(frname)
     if frcode == 0:
-        chkin('namfrm_error')
-        setmsg('frame name "{}" not found in kernel pool'.format(frname))
-        sigerr('SPICE(FRAMENAMENOTFOUND)')
-        chkout('namfrm_error')
+        with chkin_and_chkout('namfrm_error'):
+            setmsg(f'frame name "{frname}" not found in kernel pool')
+            sigerr('SPICE(FRAMENAMENOTFOUND)')
 
     return frcode
 
 def pckcov_error(pck, code):
     coverage = cspyce0.pckcov(pck, code)
     if coverage.card == 0:
-        chkin('pckcov_error')
-        setmsg('frame code {} not found in binary PC kernel file {}'.format(code, pck))
-        sigerr('SPICE(FRAMEIDNOTFOUND)')
-        chkout('pckcov_error')
+        with chkin_and_chkout('pckcov_error'):
+            setmsg(f'frame code {code} not found in binary PC kernel file {pck}')
+            sigerr('SPICE(FRAMEIDNOTFOUND)')
 
     return coverage
 
 def spkcov_error(spk, code):
     coverage = cspyce0.spkcov(spk, code)
     if coverage.card == 0:
-        chkin('spkcov_error')
-        setmsg('body code {} not found in SP kernel file {}'.format(code, spk))
-        sigerr('SPICE(BODYIDNOTFOUND)')
-        chkout('spkcov_error')
+        with chkin_and_chkout('spkcov_error'):
+            setmsg(f'body code {code} not found in SP kernel file {spk}')
+            sigerr('SPICE(BODYIDNOTFOUND)')
 
     return coverage
 
 def srfc2s_error(code, bodyid):
     (srfstr, isname) = cspyce0.srfc2s(code, bodyid)
     if not isname:
-        chkin('srfc2s_error')
-        setmsg('surface for {}/{} not found'.format(code, bodyid))
-        sigerr('SPICE(NOTRANSLATION)')
-        chkout('srfc2s_error')
+        with chkin_and_chkout('srfc2s_error'):
+            setmsg(f'surface for {code}/{bodyid} not found')
+            sigerr('SPICE(NOTRANSLATION)')
 
     return srfstr
 
 def srfcss_error(code, bodstr):
     (srfstr, isname) = cspyce0.srfcss(code, bodstr)
     if not isname:
-        chkin('srfcss_error')
-        setmsg('surface for {}/"{}" not found'.format(code, bodstr))
-        sigerr('SPICE(NOTRANSLATION)')
-        chkout('srfcss_error')
+        with chkin_and_chkout('srfcss_error'):
+            setmsg(f'surface for {code}/"{bodstr}" not found')
+            sigerr('SPICE(NOTRANSLATION)')
 
     return srfstr
 
 def srfs2c_error(srfstr, bodstr):
     (code, found) = cspyce0.srfs2c(srfstr, bodstr)
     if not found:
-        chkin('srfs2c_error')
-        setmsg('surface for "{}"/"{}" not found'.format(srfstr, bodstr))
-        sigerr('SPICE(NOTRANSLATION)')
-        chkout('srfs2c_error')
+        with chkin_and_chkout('srfs2c_error'):
+            setmsg(f'surface for "{srfstr}"/"{bodstr}" not found')
+            sigerr('SPICE(NOTRANSLATION)')
 
     return code
 
 def srfscc_error(srfstr, bodyid):
     (code, found) = cspyce0.srfscc(srfstr, bodyid)
     if not found:
-        chkin('srfscc_error')
-        setmsg('"{}"/{} not found'.format(srfstr, bodyid))
-        sigerr('SPICE(NOTRANSLATION)')
-        chkout('srfscc_error')
+        with chkin_and_chkout('srfscc_error'):
+            setmsg(f'"{srfstr}"/{bodyid} not found')
+            sigerr('SPICE(NOTRANSLATION)')
 
     return code
 
 def stpool_error(item, nth, contin):
-    (string, found) = cspyce0.stpool(item, nth, contin)
-    if not found:
-        (ok, count, nctype) = cspyce0.dtpool(name)
-        if not ok:
-            chkin('stpool_error')
-            setmsg('pool variable "{}" not found'.format(name))
-            sigerr('SPICE(VARIABLENOTFOUND)')
-            chkout('stpool_error')
-            return ''
-
-        if nth != 0:
-            (_, ok) = cspyce0.stpool(item, 0, contin)
-            if ok:
-                chkin('stpool_error')
-                setmsg('index too large; '
-                       'kernel pool has fewer than {} '
-                       'strings matching name "{}" '
-                       'and continuation "{}"'.format(nth, item, contin))
-                sigerr('SPICE(INDEXOUTOFRANGE)')
-                chkout('stpool_error')
+    with chkin_and_chkout("stpool_error"):
+        (string, found) = cspyce0.stpool(item, nth, contin)
+        if not found:
+            (ok, count, nctype) = cspyce0.dtpool(name)
+            if not ok:
+                setmsg(f'pool variable "{name}" not found')
+                sigerr('SPICE(VARIABLENOTFOUND)')
                 return ''
 
-    (ok, count, nctype) = cspyce0.dtpool(item)
-    if nctype != 'C':
-        setmsg('string values are not available; '
-               'kernel pool variable "{}" has numeric values'.format(item))
-        sigerr('SPICE(WRONGDATATYPE)')
-        chkout('stpool_error')
-        return ''
+            if nth != 0:
+                (_, ok) = cspyce0.stpool(item, 0, contin)
+                if ok:
+                    setmsg(f'index too large; '
+                           f'kernel pool has fewer than {nth} '
+                           f'strings matching name "{item}" '
+                           f'and continuation "{contin}"')
+                    sigerr('SPICE(INDEXOUTOFRANGE)')
+                    return ''
+
+        (ok, count, nctype) = cspyce0.dtpool(item)
+        if nctype != 'C':
+            setmsg(f'string values are not available; '
+                   f'kernel pool variable "{item}" has numeric values')
+            sigerr('SPICE(WRONGDATATYPE)')
+            return ''
 
     return string
 
 def tparse_error(string):
     (sp2000, msg) = cspyce0.tparse(string)
     if msg:
-        chkin('tparse_error')
-        setmsg(msg)
-        sigerr('SPICE(INVALIDTIMESTRING)')
-        chkout('tparse_error')
+        with chkin_and_chkout('tparse_error'):
+            setmsg(msg)
+            sigerr('SPICE(INVALIDTIMESTRING)')
 
     return sp2000
 
 def tpictr_error(string):
     (pictur, ok, msg) = cspyce0.tpictr(string)
     if not ok:
-        chkin('tpictr_error')
-        setmsg(msg)
-        sigerr('SPICE(INVALIDTIMESTRING)')
-        chkout('tpictr_error')
+        with chkin_and_chkout('tpictr_error'):
+            setmsg(msg)
+            sigerr('SPICE(INVALIDTIMESTRING)')
 
     return pictur
 
@@ -508,81 +468,73 @@ def tpictr_error(string):
 def ckfrot_error(inst, et):
     (rotate, ref, found) = cspyce0.ckfrot(inst, et)
     if not found:
-        chkin('ckfrot_error')
-        setmsg('Orientation data not found for instrument {} at time {}'.format(inst, et))
-        sigerr('SPICE(CKINSUFFDATA)')
-        chkout('ckfrot_error')
+        with chkin_and_chkout('ckfrot_error'):
+            setmsg(f'Orientation data not found for instrument {inst} at time {et}')
+            sigerr('SPICE(CKINSUFFDATA)')
 
     return [rotate, ref]
 
 def ckfxfm_error(inst, et):
     (rotate, ref, found) = cspyce0.ckfxfm(inst, et)
     if not found:
-        chkin('ckfxfm_error')
-        setmsg('Orientation data not found for instrument {} at time {}'.format(inst, et))
-        sigerr('SPICE(CKINSUFFDATA)')
-        chkout('ckfxfm_error')
+        with chkin_and_chkout('ckfxfm_error'):
+            setmsg(f'Orientation data not found for instrument {inst} at time {et}')
+            sigerr('SPICE(CKINSUFFDATA)')
 
     return [rotate, ref]
 
 def dafgsr_error(handle, recno, begin, end):
     (data, found) = cspyce0.dafgsr(handle, recno, begin, end)
     if not found:
-        chkin('dafgsr_error')
-        setmsg('DAF summary content not available for handle {}, '
-               'record {}, words {}-{}'.format(handle, recno, begin, end))
-        sigerr('SPICE(DAFFRNOTFOUND)')
-        chkout('dafgsr_error')
+        with chkin_and_chkout('dafgsr_error'):
+            setmsg(f'DAF summary content not available for handle {handle}, '
+                   f'record {recno}, words {begin}-{end}')
+            sigerr('SPICE(DAFFRNOTFOUND)')
 
     return data
 
 def dlabbs_error(handle):
     (dlabbs, found) = cspyce0.dlabbs(handle)
     if not found:
-        chkin('dlabbs_error')
-        setmsg(f'DLA segment not found for handle {handle}')
-        sigerr('SPICE(DASFILEREADFAILED)')
-        chkout('dlabbs_error')
+        with chkin_and_chkout('dlabbs_error'):
+            setmsg(f'DLA segment not found for handle {handle}')
+            sigerr('SPICE(DASFILEREADFAILED)')
 
     return dlabbs
 
 def dlabfs_error(handle):
     (dladsc, found) = cspyce0.dlabfs(handle)
     if not found:
-        chkin('dlabfs_error')
-        setmsg('DLA segment not found for handle {}'.format(handle))
-        sigerr('SPICE(DASFILEREADFAILED)')
-        chkout('dlabfs_error')
+        with chkin_and_chkout('dlabfs_error'):
+            setmsg(f'DLA segment not found for handle {handle}')
+            sigerr('SPICE(DASFILEREADFAILED)')
 
     return dladsc
 
 def dlafns_error(handle, dladsc):
     (nxtdsc, found) = cspyce0.dlafns(handle, dladsc)
     if not found:
-        chkin('dlafns_error')
-        setmsg('DLA segment not found for handle {}'.format(handle))
-        sigerr('SPICE(DASFILEREADFAILED)')
-        chkout('dlafns_error')
+        with chkin_and_chkout('dlafns_error'):
+            setmsg(f'DLA segment not found for handle {handle}')
+            sigerr('SPICE(DASFILEREADFAILED)')
 
     return nxtdsc
 
 def dlafps_error(handle, dladsc):
     (prvdsc, found) = cspyce0.dlafps(handle, dladsc)
     if not found:
-        chkin('dlafps_error')
-        setmsg('DLA segment not found for handle {}'.format(handle))
-        sigerr('SPICE(DASFILEREADFAILED)')
-        chkout('dlafps_error')
+        with chkin_and_chkout('dlafps_error'):
+            setmsg(f'DLA segment not found for handle {handle}')
+            sigerr('SPICE(DASFILEREADFAILED)')
 
     return prvdsc
 
 def dskx02_error(handle, dladsc, vertex, raydir):
     (plid, xpt, found) = cspyce0.dskx02(handle, dladsc, vertex, raydir)
     if not found:
-        chkin('dskx02_error')
-        setmsg('Intercept plate ID not found')
-        sigerr('SPICE(NOINTERCEPT)')
-        chkout('dskx02_error')
+        with chkin_and_chkout('dskx02_error'):
+            setmsg('Intercept plate ID not found')
+            sigerr('SPICE(NOINTERCEPT)')
 
     return [plid, xpt]
 
@@ -591,128 +543,116 @@ def dskxsi_error(pri, target, srflst, et, fixref, vertex, raydir):
                                                                   srflst, et, fixref,
                                                                   vertex, raydir)
     if not found:
-        chkin('dskxsi_error')
-        setmsg('Intercept plate ID not found')
-        sigerr('SPICE(NOINTERCEPT)')
-        chkout('dskxsi_error')
+        with chkin_and_chkout('dskxsi_error'):
+            setmsg('Intercept plate ID not found')
+            sigerr('SPICE(NOINTERCEPT)')
 
     return [xpt, handle, dladsc, dskdsc, dc, ic]
 
 def ekfind_error(query):
     (nmrows, error, errmsg) = cspyce0.ekfind(query)
     if error:
-        chkin('ekfind_error')
-        setmsg(errmsg)
-        sigerr('SPICE(INVALIDVALUE)')
-        chkout('ekfind_error')
+        with chkin_and_chkout('ekfind_error'):
+            setmsg(errmsg)
+            sigerr('SPICE(INVALIDVALUE)')
 
     return nmrows
 
 def ekgc_error(selidx, row, elment):
     (cdata, null, found) = cspyce0.ekgc(selidx, row, elment)
     if not found:
-        chkin('ekgc_error')
-        setmsg('EK item not found: column index {}, '
-               'row {}, element {}'.format(selidx, row, elment))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('ekgc_error')
+        with chkin_and_chkout('ekgc_error'):
+            setmsg(f'EK item not found: column index {selidx}, '
+                   f'row {row}, element {elment}')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
 
     return [cdata, null]
 
 def ekgd_error(selidx, row, elment):
     (ddata, null, found) = cspyce0.ekgd(selidx, row, elment)
     if not found:
-        chkin('ekgd_error')
-        setmsg('EK item not found: column index {}, '
-               'row {}, element {}'.format(selidx, row, elment))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('ekgd_error')
+        with chkin_and_chkout('ekgd_error'):
+            setmsg(f'EK item not found: column index {selidx}, '
+                   f'row {row}, element {elment}')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
 
     return [ddata, null]
 
 def ekgi_error(selidx, row, elment):
     (idata, null, found) = cspyce0.ekgi(selidx, row, elment)
     if not found:
-        chkin('ekgi_error')
-        setmsg('EK item not found: column index {}, '
-               'row {}, element {}'.format(selidx, row, elment))
-        sigerr('SPICE(INDEXOUTOFRANGE)')
-        chkout('ekgi_error')
+        with chkin_and_chkout('ekgi_error'):
+            setmsg(f'EK item not found: column index {selidx}, '
+                   f'row {row}, element {elment}')
+            sigerr('SPICE(INDEXOUTOFRANGE)')
 
     return [idata, null]
 
 def ekpsel_error(query):
     (xbegs, xends, xtypes, xclass, tabs, cols, error, errmsg) = cspyce0.ekpsel(query)
     if error:
-        chkin('ekpsel_error')
-        setmsg(errmsg)
-        sigerr('SPICE(INVALIDVALUE)')
-        chkout('ekpsel_error')
+        with chkin_and_chkout('ekpsel_error'):
+            setmsg(errmsg)
+            sigerr('SPICE(INVALIDVALUE)')
 
     return [xbegs, xends, xtypes, xclass, tabs, cols]
 
 def hx2dp_error(string):
     (number, error, errmsg) = cspyce0.hx2dp(string)
     if error:
-        chkin('hx2dp_error')
-        setmsg(errmsg)
-        sigerr('SPICE(INVALIDVALUE)')
-        chkout('hx2dp_error')
+        with chkin_and_chkout('hx2dp_error'):
+            setmsg(errmsg)
+            sigerr('SPICE(INVALIDVALUE)')
 
     return number
 
 def kdata_error(which, kind):
     (file, filtype, srcfil, handle, found) = cspyce0.kdata(which, kind)
     if not found:
-        chkin('kdata_error')
-        count = cspyce0.ktotal(kind)
-        if which >= count:
-            setmsg('index out of range: {}/{}, {}'.format(which, count, kind))
-            sigerr('SPICE(INVALIDINDEX)')
-        else:
-            setmsg('kernel not found: {}, {}'.format(which, kind))
-            sigerr('SPICE(FILENOTFOUND)')
-        chkout('kdata_error')
+        with chkin_and_chkout('kdata_error'):
+            count = cspyce0.ktotal(kind)
+            if which >= count:
+                setmsg(f'index out of range: {which}/{count}, {kind}')
+                sigerr('SPICE(INVALIDINDEX)')
+            else:
+                setmsg(f'kernel not found: {which}, {kind}')
+                sigerr('SPICE(FILENOTFOUND)')
 
     return [file, filtype, srcfil, handle]
 
 def kinfo_error(file):
     (filtyp, srcfil, handle, found) = cspyce0.kinfo(file)
     if not found:
-        chkin('kinfo_error')
-        setmsg('kernel file not found: ' + file)
-        sigerr('SPICE(FILENOTFOUND)')
-        chkout('kinfo_error')
+        with chkin_and_chkout('kinfo_error'):
+            setmsg(f'kernel file not found: {file}')
+            sigerr('SPICE(FILENOTFOUND)')
 
     return [filtyp, srcfil, handle]
 
 def spksfs_error(body, et,):
     (handle, descr, ident, found) = cspyce0.spksfs(body, et)
     if not found:
-        chkin('spksfs_error')
-        setmsg('SPK segment not found for body "{}", time {}'.format(body, et))
-        sigerr('SPICE(SPKINSUFFDATA)')
-        chkout('spksfs_error')
+        with chkin_and_chkout('spksfs_error'):
+            setmsg(f'SPK segment not found for body "{body}", time {et}')
+            sigerr('SPICE(SPKINSUFFDATA)')
 
     return [handle, descr, ident]
 
 def szpool_error(name):
     (n, found) = cspyce0.szpool(name)
     if not found:
-        chkin('szpool_error')
-        setmsg('kernel pool size limit "{}" not found'.format(name))
-        sigerr('SPICE(KERNELVARNOTFOUND)')
-        chkout('szpool_error')
+        with chkin_and_chkout('szpool_error'):
+            setmsg(f'kernel pool size limit "{name}" not found')
+            sigerr('SPICE(KERNELVARNOTFOUND)')
 
     return n
 
 def tkfram_error(frcode):
     (rot, frame, found) = cspyce0.tkfram(frcode)
     if not found:
-        chkin('tkfram_error')
-        setmsg('rotation matrix for frame {} not found'.format(frcode))
-        sigerr('SPICE(FRAMEIDNOTFOUND)')
-        chkout('tkfram_error')
+        with chkin_and_chkout('tkfram_error'):
+            setmsg(f'rotation matrix for frame {frcode} not found')
+            sigerr('SPICE(FRAMEIDNOTFOUND)')
 
     return [rot, frame]
 
@@ -734,13 +674,12 @@ def ckgp_vector_error(inst, sclkdp, tol, ref):
         else:
             clockstr = '%s to %s' % (sclkdp_min, sclkdp_max)
 
-        chkin('ckgp_vector_error')
-        setmsg('insufficient C kernel data to evaluate ' +
-               'instrument/spacecraft %s%s ' % (inst, namestr) +
-               'at spacecraft clock times %s ' % clockstr +
-               'with tolerance %s' % np.min(tol))
-        sigerr('SPICE(CKINSUFFDATA)')
-        chkout('ckgp_vector_error')
+        with chkin_and_chkout('ckgp_vector_error'):
+            setmsg(f'insufficient C kernel data to evaluate '
+                   f'instrument/spacecraft {inst}{namestr} ' 
+                   f'at spacecraft clock times {clockstr} '
+                   f'with tolerance {np.min(tol)}')
+            sigerr('SPICE(CKINSUFFDATA)')
 
     return [cmat, clkout]
 
@@ -760,23 +699,21 @@ def ckgpav_vector_error(inst, sclkdp, tol, ref):
         else:
             clockstr = '%s to %s' % (sclkdp_min, sclkdp_max)
 
-        chkin('ckgpav_vector_error')
-        setmsg('insufficient C kernel data to evaluate ' +
-               'instrument/spacecraft %s%s ' % (inst, namestr) +
-               'at spacecraft clock times %s ' % clockstr +
-               'with tolerance %s' % np.min(tol))
-        sigerr('SPICE(CKINSUFFDATA)')
-        chkout('ckgpav_vector_error')
+        with chkin_and_chkout('ckgpav_vector_error'):
+            setmsg(f'insufficient C kernel data to evaluate '
+                   f'instrument/spacecraft {inst}{namestr} ' 
+                   f'at spacecraft clock times {clockstr} '
+                   f'with tolerance {np.min(tol)}')
+            sigerr('SPICE(CKINSUFFDATA)')
 
     return [cmat, av, clkout]
 
 def invert_error(m1):
     inverse = cspyce0.invert(m1)
     if np.all(inverse == 0.):
-        chkin('invert_error')
-        setmsg('singular matrix encountered; inverse failed')
-        sigerr('SPICE(SINGULARMATRIX)')
-        chkout('invert_error')
+        with chkin_and_chkout('invert_error'):
+            setmsg('singular matrix encountered; inverse failed')
+            sigerr('SPICE(SINGULARMATRIX)')
 
     return inverse
 
@@ -784,10 +721,9 @@ def invert_vector_error(m1):
     inverses = cspyce0.invert_vector(m1)
     tests = np.all(inverses == 0., (-2,-1))
     if np.any(tests):
-        chkin('invert_error')
-        setmsg('singular matrix encountered; inverse failed')
-        sigerr('SPICE(SINGULARMATRIX)')
-        chkout('invert_error')
+        with chkin_and_chkout('invert_error'):
+            setmsg('singular matrix encountered; inverse failed')
+            sigerr('SPICE(SINGULARMATRIX)')
 
     return inverses
 

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -672,10 +672,6 @@ class TestPrimitiveReturnTypes:
         assert ts.return_boolean(100) is True
         assert ts.return_boolean(0) is False
 
-    def test_sigerror(self):
-        with pytest.raises(RuntimeError):
-            ts.return_sigerr()
-
 
 class TestReturnValueThroughOutvar:
     # Each of the functions used here is defined in C as a void function with

--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -8153,7 +8153,7 @@ extern void sctiks_c(
 ***********************************************************************/
 
 %rename (sigerr) sigerr_c;
-%apply (void RETURN_VOID_SIGERR) {void sigerr_c};
+%apply (void RETURN_VOID) {void sigerr_c};
 
 extern void sigerr_c(
         ConstSpiceChar *CONST_STRING

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -387,10 +387,6 @@ void sort_strings(SpiceInt rows, SpiceInt columns, SpiceChar* array);
     SpiceInt return_boolean(SpiceInt value) {
         return value;
     }
-
-    void return_sigerr(void) {
-    }
-
 %}
 
 %apply (SpiceChar *RETURN_STRING) {const SpiceChar* return_string};
@@ -398,9 +394,6 @@ const SpiceChar* return_string();
 
 %apply (SpiceInt RETURN_BOOLEAN) {SpiceInt return_boolean};
 SpiceInt return_boolean(SpiceInt value);
-
-%apply (void RETURN_VOID_SIGERR) {void return_sigerr};
-void return_sigerr(void);
 
 %{
     void outvar_set_from_var_int(SpiceInt in, SpiceInt* out) { *out = in; }

--- a/unittests/test_errors.py
+++ b/unittests/test_errors.py
@@ -126,7 +126,10 @@ def test_set_msg():
     assert msg == 'Long pi=3.1415900000000E+00; four=4; foo="FOO"'
 
 
-def test_output_to_screen(capfd):
+def fail_output_to_screen(capfd):
+    # This test seems to run fine when run singly, but fails when run as part of a
+    # larger pytest.  Somehow the ability to catch what is written to stdout is
+    # different.  Need to investigate.
     s.errdev('set', 'screen')
     s.chkin('Name1')
     s.chkout('Name2')

--- a/unittests/test_errors.py
+++ b/unittests/test_errors.py
@@ -126,7 +126,7 @@ def test_set_msg():
     assert msg == 'Long pi=3.1415900000000E+00; four=4; foo="FOO"'
 
 
-def test_output_to_screen(capfd):
+def fail_output_to_screen(capfd):
     # This test seems to run fine when run singly, but fails when run as part of a
     # larger pytest.  Somehow the ability to catch what is written to stdout is
     # different.  Need to investigate.

--- a/unittests/test_errors.py
+++ b/unittests/test_errors.py
@@ -6,7 +6,25 @@ import cspyce as s
 import pytest
 
 
-def test_erract_errdev_errprt():
+def cleanup_errors():
+    length = s.trcdep()
+    for index in reversed(range(length)):
+        module = s.trcnam(index)
+        s.chkout(module)
+    s.reset()
+    s.erract('SET', 'EXCEPTION')
+    s.errdev('SET', 'NULL')
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    cleanup_errors()
+    yield
+    cleanup_errors()
+
+
+def test_erract_set_and_get():
+    cleanup_errors()
     assert s.erract() == 'EXCEPTION'
     assert s.erract('GET') == 'EXCEPTION'
     assert s.erract('GET', 'ignored') == 'EXCEPTION'
@@ -21,7 +39,11 @@ def test_erract_errdev_errprt():
     s.erract('set', '  exception')
     assert s.erract() == 'EXCEPTION'
 
-    assert s.errdev() == 'NULL'
+    s.erract('set', 'exception')
+    assert s.erract() == 'EXCEPTION'
+
+
+def test_errdev_set_and_get():
     assert s.errdev('GET') == 'NULL'
     assert s.errdev('GET', 'ignored') == 'NULL'
     assert s.errdev('SET', 'foo.txt') == 'foo.txt'
@@ -29,10 +51,15 @@ def test_erract_errdev_errprt():
     assert s.errdev() == 'bar.txt'
     assert s.errdev('SET', 'SCREEN') == 'SCREEN'
     assert s.errdev() == 'SCREEN'
-
     assert s.errdev('SET', 'NULL') == 'NULL'
     assert s.errdev() == 'NULL'
+    assert s.errdev() == 'NULL'
 
+    s.errdev('set', 'screen')
+    assert s.errdev() == 'SCREEN'
+
+
+def test_errprt_set_and_get():
     default = 'SHORT, LONG, EXPLAIN, TRACEBACK, DEFAULT'
     assert s.errprt() == default
     assert s.errprt('GET') == default
@@ -47,237 +74,49 @@ def test_erract_errdev_errprt():
     assert s.errprt(default) == default
     assert s.errprt() == default
 
-    #### chkin, chkout, trcdep, trcnam, qcktrc, sigerr with Python exceptions
 
-    s.erract('set', 'exception')
-    assert s.erract() == 'EXCEPTION'
-    s.erract('SET', ' ExcEptIon  ')
-    assert s.erract() == 'EXCEPTION'
-    s.errdev('set', 'screen')
-    assert s.errdev() == 'SCREEN'
-
+def test_chkin_quicktrace():
     s.chkin('zero')
     s.chkin('one')
     s.chkin('two')
-    print(s.qcktrc())
     assert s.trcdep() == 3
     assert s.trcnam(0) == 'zero'
     assert s.trcnam(1) == 'one'
     assert s.trcnam(2) == 'two'
     assert s.qcktrc() == 'zero --> one --> two'
 
-    print()
-    print('*** One RuntimeError message should appear below')
-    print('*** SPICE(INVALIDARRAYSHAPE) --')
-    print('*** Traceback: zero --> one --> two --> vadd')
     s.erract('RUNTIME')
-    with pytest.raises(RuntimeError):
-        s.vadd([1,2,3], [4,5,6,7])
-
-    print()
-    print('*** One ValueError message should appear below')
-    print('*** SPICE(INVALIDARRAYSHAPE) --')
-    print('*** Traceback: zero --> one --> two --> vadd')
-    s.erract('EXCEPTION')
-    with pytest.raises(ValueError):
-        s.vadd([1,2,3], [4,5,6,7])
+    try:
+        s.vadd([1, 2, 3], [4, 5, 6, 7])
+    except RuntimeError as e:
+        exception = e
+        # TODO(fy): We should be seeing zero --> one --> two --> vadd
+        # somewhere in the traceback, but we're not.
 
     assert s.trcdep() == 3
     assert s.trcnam(2) == 'two'
     assert s.getmsg('short') == 'SPICE(INVALIDARRAYSHAPE)'
+    assert str(exception) == s.getmsg('short') + ' -- vadd -- ' + s.getmsg('long')
 
-    s.errdev('set', 'null')
-    try:
-        s.vadd([1,2,3], [4,5,6,7])
-    except ValueError as error:
-        e = error
 
-    assert str(e) == s.getmsg('short') + ' -- vadd -- ' + s.getmsg('long')
-
-    s.errdev('set', 'screen')
-    print()
-    print('*** One error message should appear below')
-    print('*** Error test -- \\n\\nThis is an error test')
-    print('*** Traceback: zero --> one --> two')
-    s.setmsg('This is an error test')
-    with pytest.raises(RuntimeError):
-        s.sigerr("Error test")
-
-    assert s.trcdep() == 2
-    s.errdev('set', 'null')
-
-    with pytest.raises(RuntimeError):
-        s.sigerr("Error test")
-    assert s.getmsg('short') == 'Error test'
-    assert not s.failed()
-    assert s.trcdep() == 1
-    assert s.qcktrc() == 'zero'
-
-    s.reset()
-
-    assert s.getmsg('short') == ''
-    assert s.trcdep() == 1
-    assert s.qcktrc() == 'zero'
-
-    with pytest.raises(RuntimeError):
-        s.sigerr("222")
-    assert s.getmsg('short') == '222'
-    assert not s.failed()
-    assert s.trcdep() == 0
-    assert s.qcktrc() == ''
-
-    with pytest.raises(RuntimeError):
-        s.sigerr("333")
-    assert s.getmsg('short') == '333'
-    assert not s.failed()
-    assert s.trcdep() == 0
-    assert s.qcktrc() == ''
-
-    s.reset()
-
-    assert s.getmsg('short') == ''
-
+def test_external_errors():
     with pytest.raises(KeyError):
         s.bodn2c('abc')
     assert s.getmsg('short') == 'SPICE(BODYNAMENOTFOUND)'
     assert s.getmsg('long') == 'body name "abc" not found in kernel pool'
     assert not s.failed()
 
-    #### chkin, chkout, trcdep, trcnam, sigerr with erract="EXCEPTION"
 
-    s.erract('set', 'exception')
-    assert s.erract() == 'EXCEPTION'
-    s.errdev('set', 'screen')
-    s.chkin('zero')
-    s.chkin('one')
-    s.chkin('two')
-    assert s.trcdep() == 3
-    assert s.trcnam(0) == 'zero'
-    assert s.trcnam(1) == 'one'
-    assert s.trcnam(2) == 'two'
-    assert s.qcktrc() == 'zero --> one --> two'
-
-    print()
-    print('*** One error message should appear below')
-    print('*** SPICE(INVALIDARRAYSHAPE) --')
-    print('*** Traceback: zero --> one --> two --> vadd')
-    try:
-        _ = s.vadd([1,2,3], [4,5,6,7])
-    except ValueError as e:
-        print(e)
-
-    assert s.trcdep() == 3
-    assert s.trcnam(2) == 'two'
-    assert s.getmsg('short') == 'SPICE(INVALIDARRAYSHAPE)'
-    assert s.qcktrc() == 'zero --> one --> two'
-
-    s.reset()
-
-    assert s.trcdep() == 3
-    assert s.trcnam(2) == 'two'
-    assert s.getmsg('short') == ''
-    assert not s.failed()
-    assert s.qcktrc() == 'zero --> one --> two'
-
-    print()
-    print('*** One error message should appear below')
-    print('*** Error test -- \\n\\nThis is an error test')
-    print('*** Traceback: zero --> one --> two')
-
-    s.setmsg('This is an error test')
-    try:
-        s.sigerr("Error test")
-    except RuntimeError as e:
-        print(e)
-
-    assert s.trcdep() == 2
-    assert s.trcnam(1) == 'one'
-    assert s.getmsg('short') == 'Error test'
-    assert s.getmsg('long') == 'This is an error test'
-    assert s.qcktrc() == 'zero --> one'
-
-    s.reset()
-
-    assert s.trcdep() == 2
-    assert s.trcnam(1) == 'one'
-    assert s.getmsg('short') == ''
-    assert s.getmsg('long') == ''
-    assert not s.failed()
-    assert s.qcktrc() == 'zero --> one'
-
-    s.errdev('set', 'null')
-    try:
-        s.sigerr("Error test")
-    except RuntimeError as e:
-        pass
-
-    assert s.trcdep() == 1
-    assert s.getmsg('short') == 'Error test'
-    assert s.getmsg('long') == ''
-    assert s.qcktrc() == 'zero'
-
-    s.reset()
-
-    assert s.trcdep() == 1
-    assert s.getmsg('short') == ''
-    assert not s.failed()
-    assert s.qcktrc() == 'zero'
-
-    try:
-        s.sigerr("222")
-    except RuntimeError as e:
-        pass
-
-    assert s.trcdep() == 0
-    assert s.getmsg('short') == '222'
-    assert s.getmsg('long') == ''
-    assert s.qcktrc() == ''
-
-    s.reset()
-
-    assert s.trcdep() == 0
-    assert s.getmsg('short') == ''
-    assert s.qcktrc() == ''
-
-    try:
-        s.sigerr("333")
-    except RuntimeError as e:
-        pass
-
-    assert s.trcdep() == 0
-    assert s.getmsg('short') == '333'
-    assert s.getmsg('long') == ''
-    assert s.qcktrc() == ''
-
-    s.reset()
-
-    assert s.trcdep() == 0
-    assert s.getmsg('short') == ''
-    assert s.qcktrc() == ''
-
-    #### setmsg, errdp, errint, errch
-
-    s.erract('set', 'exception')
-
-    with pytest.raises(RuntimeError):
-        s.sigerr('Short')
-    assert not s.failed()
-
-    try:
-        s.sigerr('Short')
-    except RuntimeError as e:
-        error = e
-
-    assert str(error) == 'Short -- '
-
+def test_Setting_msg_and_error():
     s.setmsg('Long')
     try:
         s.sigerr('Short')
     except RuntimeError as e:
         error = e
+    assert str(error) == 'Short -- sigerr -- Long'
 
-    assert str(error) == 'Short -- Long'
 
+def test_set_msg():
     s.setmsg('Long pi=#; four=#; foo="#"')
     assert s.getmsg('LONG') == 'Long pi=#; four=#; foo="#"'
     s.errdp('#', 3.14159)
@@ -286,29 +125,20 @@ def test_erract_errdev_errprt():
     msg = s.getmsg('LONG')
     assert msg == 'Long pi=3.1415900000000E+00; four=4; foo="FOO"'
 
-    s.chkin('foo')
-    s.chkin('bar')
-    assert s.trcdep() == 2
-    assert s.trcnam(1) == 'bar'
 
-    try:
-        s.sigerr('Short')
-    except RuntimeError as e:
-        error = e
+def test_output_to_screen(capfd):
+    s.errdev('set', 'screen')
+    s.chkin('Name1')
+    s.chkout('Name2')
+    out, _err = capfd.readouterr()
+    assert "Caller is Name2" in out
+    assert "popped name is Name1" in out
 
-    assert str(error) == 'Short -- bar -- ' + msg
-    assert s.getmsg('short') == 'Short'
-    assert s.getmsg('long') == msg
-    assert s.trcdep() == 1
-    assert s.trcnam(0) == 'foo'
 
-    s.reset()
-
-    assert s.getmsg('short') == ''
-    assert s.getmsg('long') == ''
-    assert s.trcdep() == 1
-    assert s.trcnam(0) == 'foo'
-
-    s.chkout('foo')
-
-    assert s.trcdep() == 0
+def test_no_output_to_screen(capfd):
+    s.errdev('set', 'NULL')
+    s.chkin('Name1')
+    s.chkout('Name2')
+    out, err = capfd.readouterr()
+    assert not out
+    assert not err

--- a/unittests/test_errors.py
+++ b/unittests/test_errors.py
@@ -126,16 +126,17 @@ def test_set_msg():
     assert msg == 'Long pi=3.1415900000000E+00; four=4; foo="FOO"'
 
 
-def fail_output_to_screen(capfd):
+def test_output_to_screen(capfd):
     # This test seems to run fine when run singly, but fails when run as part of a
     # larger pytest.  Somehow the ability to catch what is written to stdout is
     # different.  Need to investigate.
     s.errdev('set', 'screen')
     s.chkin('Name1')
     s.chkout('Name2')
-    out, _err = capfd.readouterr()
-    assert "Caller is Name2" in out
-    assert "popped name is Name1" in out
+    output = capfd.readouterr()
+    print(output)
+    assert "Caller is Name2" in output.out
+    assert "popped name is Name1" in output.out
 
 
 def test_no_output_to_screen(capfd):

--- a/unittests/test_kernels.py
+++ b/unittests/test_kernels.py
@@ -94,23 +94,6 @@ def assert_all_equal(arg1, arg2, tol=1.e-15, frac=False):
         else:
             assert abs(arg1 - arg2) <= tol
 
-@pytest.fixture
-def CASSINI_ET():
-    return 17.65 * 365.25 * 86400.
-
-@pytest.fixture
-def CASSINI_ET2(CASSINI_ET):
-    return CASSINI_ET + 86400
-
-@pytest.fixture
-def eps():
-    if platform.machine() == 'arm64':
-        # TODO(fy,rf,mrs): This code gives slightly different results on MacOS Arm64.
-        # This lowering of expectations needs to be investigated. Is it Mac only?
-        eps = 1e-5
-    else:
-        assert arg1 == arg2
-
 
 def assert_all_close(arg1, arg2, tol=1.e-8):
     return assert_all_equal(arg1, arg2, tol, frac=True)
@@ -373,7 +356,7 @@ def test_ckgp_ckgpav():
                          [-0.03169184, -0.92563955, 0.37707699],
                          [-0.99450248, 0.06687415, 0.08057704]])
 
-        result2b = np.array([3.46254953e-05, 5.05354838e-06, -1.12043171e-05])
+    result2b = np.array([3.46254953e-05, 5.05354838e-06, -1.12043171e-05])
 
     assert_all_equal(array2a, result2a, 5.e-9)
     assert_all_equal(array2b, result2b, 4.e-14)
@@ -521,10 +504,10 @@ def test_frmchg_sxform_pxform_xf2rav_pxfrm2_refchg():
     assert_all_equal(sat1a[:3, :3], sat1e, 0)
     assert_all_equal(sat1a[:3, :3], sat1a[3:, 3:], 0)  # true even for rotating frames
 
-        (mat0a, vec0a) = xf2rav(sat0a)
-        (mat1a, vec1a) = xf2rav(sat1a)
-        (mat0b, vec0b) = xf2rav(sat0b)
-        (mat1b, vec1b) = xf2rav(sat1b)
+    (mat0a, vec0a) = xf2rav(sat0a)
+    (mat1a, vec1a) = xf2rav(sat1a)
+    (mat0b, vec0b) = xf2rav(sat0b)
+    (mat1b, vec1b) = xf2rav(sat1b)
 
     assert_all_equal(sat0a[:3, :3], mat0a, 0)
     assert_all_equal(sat1a[:3, :3], mat1a, 0)
@@ -1016,4 +999,3 @@ def test_tsetyr():
 def test_unitim():
     assert_all_close(unitim(0., 'TAI', 'TDB'), 32.183927274)
     assert_all_close(unitim(0., 'TAI', 'JED'), 2451545.00037)
-

--- a/unittests/test_kernels.py
+++ b/unittests/test_kernels.py
@@ -49,9 +49,11 @@ def kernels():
 def CASSINI_ET():
     return 17.65 * 365.25 * 86400.
 
+
 @pytest.fixture
 def CASSINI_ET2(CASSINI_ET):
     return CASSINI_ET + 86400
+
 
 @pytest.fixture
 def eps():
@@ -64,905 +66,954 @@ def eps():
     return eps
 
 
-class Test_cspyce1_kernels:
-    def assertAllEqual(self, arg1, arg2, tol=1.e-15, frac=False):
-        if isinstance(arg1, list):
-            assert type(arg2) == list
-            assert len(arg1) == len(arg2)
-            for (item1, item2) in zip(arg1, arg2):
-                self.assertAllEqual(item1, item2, tol, frac)
+def assert_all_equal(arg1, arg2, tol=1.e-15, frac=False):
+    if isinstance(arg1, list):
+        assert type(arg2) == list
+        assert len(arg1) == len(arg2)
+        for (item1, item2) in zip(arg1, arg2):
+            assert_all_equal(item1, item2, tol, frac)
 
-        elif isinstance(arg1, np.ndarray):
-            arg1 = np.array(arg1)
-            arg2 = np.array(arg2)
-            assert arg1.shape == arg2.shape
-            arg1 = arg1.flatten()
-            arg2 = arg2.flatten()
-            for (x1, x2) in zip(arg1, arg2):
-                if isinstance(x1, numbers.Real):
-                    if frac:
-                        assert abs(x1 - x2) <= tol * abs(x1 + x2) / 2.
-                    else:
-                        assert abs(x1 - x2) <= tol
+    elif isinstance(arg1, np.ndarray):
+        arg1 = np.array(arg1)
+        arg2 = np.array(arg2)
+        assert arg1.shape == arg2.shape
+        arg1 = arg1.flatten()
+        arg2 = arg2.flatten()
+        for (x1, x2) in zip(arg1, arg2):
+            if isinstance(x1, numbers.Real):
+                if frac:
+                    assert abs(x1 - x2) <= tol * abs(x1 + x2) / 2.
                 else:
-                    assert x1 == x2, tol
-
-        elif isinstance(arg1, numbers.Real):
-            if frac:
-                assert abs(arg1 - arg2) <= tol * abs(arg1 + arg2) / 2.
+                    assert abs(x1 - x2) <= tol
             else:
-                assert abs(arg1 - arg2) <= tol
+                assert x1 == x2, tol
 
+    elif isinstance(arg1, numbers.Real):
+        if frac:
+            assert abs(arg1 - arg2) <= tol * abs(arg1 + arg2) / 2.
         else:
-            assert arg1 == arg2
+            assert abs(arg1 - arg2) <= tol
 
-    def assertAllClose(self, arg1, arg2, tol=1.e-8):
-        return self.assertAllEqual(arg1, arg2, tol, frac=True)
+@pytest.fixture
+def CASSINI_ET():
+    return 17.65 * 365.25 * 86400.
+
+@pytest.fixture
+def CASSINI_ET2(CASSINI_ET):
+    return CASSINI_ET + 86400
+
+@pytest.fixture
+def eps():
+    if platform.machine() == 'arm64':
+        # TODO(fy,rf,mrs): This code gives slightly different results on MacOS Arm64.
+        # This lowering of expectations needs to be investigated. Is it Mac only?
+        eps = 1e-5
+    else:
+        assert arg1 == arg2
 
 
-    #### Not tested: dafbfs, dafcls, dafgda, dafgn, dafgs, daffna, dafopr, dafus
-    #### Not tested: stcf01, stcg01, stcl01, stcl01
+def assert_all_close(arg1, arg2, tol=1.e-8):
+    return assert_all_equal(arg1, arg2, tol, frac=True)
 
-    def test_gipool(self):
-        # This test adapted from pipool_c.html
-        pipool('FRAME_MYTOPO', [1500000])
-        pcpool('FRAME_1500000_NAME', ['MYTOPO'])
-        pipool('FRAME_1500000_CLASS', [4])
-        pipool('FRAME_1500000_CLASS_ID', [1500000])
-        pipool('FRAME_1500000_CENTER', [300000])
-        pcpool('OBJECT_300000_FRAME', ['MYTOPO'])
-        pcpool('TKFRAME_MYTOPO_RELATIVE', ['J2000'])
-        pcpool('TKFRAME_MYTOPO_SPEC', ['ANGLES'])
-        pcpool('TKFRAME_MYTOPO_UNITS', ['DEGREES'])
-        pipool('TKFRAME_MYTOPO_AXES', [3, 2, 3])
-        pdpool('TKFRAME_MYTOPO_ANGLES', [22.2, 0., -22.2])
-        et = 0.
 
-        rmat = pxform('J2000', 'MYTOPO', et)
-        self.assertAllEqual(rmat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
+#### Not tested: dafbfs, dafcls, dafgda, dafgn, dafgs, daffna, dafopr, dafus
+#### Not tested: stcf01, stcg01, stcl01, stcl01
 
-        et = 10. * 365. * 86400.
-        rmat = pxform('J2000', 'MYTOPO', et)
-        self.assertAllEqual(rmat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-        pcpool('CTEST', ['LARRY', 'MOE', 'CURLY'])
-        pipool('ITEST', [3141, 186, 282])
-        pdpool('DTEST', [3.1415, 186.282, .0175])
+def test_gipool():
+    # This test adapted from pipool_c.html
+    pipool('FRAME_MYTOPO', [1500000])
+    pcpool('FRAME_1500000_NAME', ['MYTOPO'])
+    pipool('FRAME_1500000_CLASS', [4])
+    pipool('FRAME_1500000_CLASS_ID', [1500000])
+    pipool('FRAME_1500000_CENTER', [300000])
+    pcpool('OBJECT_300000_FRAME', ['MYTOPO'])
+    pcpool('TKFRAME_MYTOPO_RELATIVE', ['J2000'])
+    pcpool('TKFRAME_MYTOPO_SPEC', ['ANGLES'])
+    pcpool('TKFRAME_MYTOPO_UNITS', ['DEGREES'])
+    pipool('TKFRAME_MYTOPO_AXES', [3, 2, 3])
+    pdpool('TKFRAME_MYTOPO_ANGLES', [22.2, 0., -22.2])
+    et = 0.
 
-        # This doesn't work, but calls to expool below work fine.
-        #     self.assertTrue(expool('CTEST'))
-        assert expool('ITEST')
-        assert expool('DTEST')
-        assert not expool('DTESTxxx')
+    rmat = pxform('J2000', 'MYTOPO', et)
+    assert_all_equal(rmat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-        assert dtpool('CTEST') == [3, 'C']
-        assert dtpool('ITEST') == [3, 'N']
-        assert dtpool('DTEST') == [3, 'N']
-        with pytest.raises(KeyError):
-            dtpool('DTESTxxx')
+    et = 10. * 365. * 86400.
+    rmat = pxform('J2000', 'MYTOPO', et)
+    assert_all_equal(rmat, [[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-        assert dtpool.flag('CTEST') == [True, 3, 'C']
-        assert dtpool.flag('ITEST') == [True, 3, 'N']
-        assert dtpool.flag('DTEST') == [True, 3, 'N']
-        assert dtpool.flag('DTESTxxx')[0] == False
+    pcpool('CTEST', ['LARRY', 'MOE', 'CURLY'])
+    pipool('ITEST', [3141, 186, 282])
+    pdpool('DTEST', [3.1415, 186.282, .0175])
 
-        assert list(gipool('ITEST')) == [3141, 186, 282]
-        assert list(gdpool('DTEST')) == [3.1415, 186.282, .0175]
-        assert list(gcpool('CTEST')) == ['LARRY', 'MOE', 'CURLY']
+    # This doesn't work, but calls to expool below work fine.
+    #     self.assertTrue(expool('CTEST'))
+    assert expool('ITEST')
+    assert expool('DTEST')
+    assert not expool('DTESTxxx')
 
-        assert list(gipool('ITEST', 1)) == [186, 282]
-        assert list(gdpool('DTEST', 1)) == [186.282, .0175]
-        assert list(gcpool('CTEST', 1)) == ['MOE', 'CURLY']
+    assert dtpool('CTEST') == [3, 'C']
+    assert dtpool('ITEST') == [3, 'N']
+    assert dtpool('DTEST') == [3, 'N']
+    with pytest.raises(KeyError):
+        dtpool('DTESTxxx')
 
-        with pytest.raises(KeyError):
-            gipool('ITESTxxx')
-        with pytest.raises(KeyError):
-            gdpool('DTESTxxx')
-        with pytest.raises(KeyError):
-            gcpool('CTESTxxx')
+    assert dtpool.flag('CTEST') == [True, 3, 'C']
+    assert dtpool.flag('ITEST') == [True, 3, 'N']
+    assert dtpool.flag('DTEST') == [True, 3, 'N']
+    assert dtpool.flag('DTESTxxx')[0] == False
 
-        assert len(gipool.flag('ITEST')) == 2
-        assert len(gdpool.flag('DTEST')) == 2
-        assert len(gcpool.flag('CTEST')) == 2
+    assert list(gipool('ITEST')) == [3141, 186, 282]
+    assert list(gdpool('DTEST')) == [3.1415, 186.282, .0175]
+    assert list(gcpool('CTEST')) == ['LARRY', 'MOE', 'CURLY']
 
-        assert gipool.flag('ITEST')[-1]
-        assert gdpool.flag('DTEST')[-1]
-        assert gcpool.flag('CTEST')[-1]
-        assert not gcpool.flag('CTESTxxx')[-1]
+    assert list(gipool('ITEST', 1)) == [186, 282]
+    assert list(gdpool('DTEST', 1)) == [186.282, .0175]
+    assert list(gcpool('CTEST', 1)) == ['MOE', 'CURLY']
 
-    def test_clpool_dlpool(self):
-        #### clpool, ldpool
-        assert bodfnd(599, 'RADII')
-        assert bodfnd(699, 'RADII')
-        clpool()
-        assert not bodfnd(699, 'RADII')
-        ldpool(PATH_ / 'pck00010.tpc')
-        assert bodfnd(699, 'RADII')
+    with pytest.raises(KeyError):
+        gipool('ITESTxxx')
+    with pytest.raises(KeyError):
+        gdpool('DTESTxxx')
+    with pytest.raises(KeyError):
+        gcpool('CTESTxxx')
 
-    def test_expool_dtpool(self):
-        assert expool('BODY699_RADII')
-        assert not expool('BODY699_RADIIxxx')
-        assert dtpool_error('BODY699_RADII') == [3, 'N']
-        assert dtpool.flag('BODY699_RADII') == [True, 3, 'N']
-        assert dtpool.flag('BODY699_RADIIxxx')[0] == False
-        with pytest.raises(KeyError):
-            dtpool_error('BODY699_RADIIxxx')
+    assert len(gipool.flag('ITEST')) == 2
+    assert len(gdpool.flag('DTEST')) == 2
+    assert len(gcpool.flag('CTEST')) == 2
 
-    def test_gnpool(self):
-        assert set(gnpool('BODY699*RA*')) == set(['BODY699_POLE_RA',
-                                                          'BODY699_RADII'])
-        with pytest.raises(KeyError):
-            gnpool('BODY699*RAxxx*')
+    assert gipool.flag('ITEST')[-1]
+    assert gdpool.flag('DTEST')[-1]
+    assert gcpool.flag('CTEST')[-1]
+    assert not gcpool.flag('CTESTxxx')[-1]
 
-        assert set(gnpool.flag('BODY699*RA*')[0]) == \
-                         set(['BODY699_POLE_RA', 'BODY699_RADII'])
-        assert gnpool.flag('BODY699*RA*')[1]
-        assert not gnpool.flag('BODY699*RAxxx*')[1]
 
-    def test_stpool(self):
-        SPK_FILES = ['this_is_the_full_path_specification_*',
-                     'of_a_file_with_a_long_name',
-                     'this_is_the_full_path_specification_*',
-                     'of_a_second_file_with_a_very_long_*',
-                     'name']
-        pcpool('SPK_FILES', SPK_FILES)
+def test_clpool_dlpool():
+    #### clpool, ldpool
+    assert bodfnd(599, 'RADII')
+    assert bodfnd(699, 'RADII')
+    clpool()
+    assert not bodfnd(699, 'RADII')
+    ldpool(PATH_ / 'pck00010.tpc')
+    assert bodfnd(699, 'RADII')
 
-        assert stpool('SPK_FILES', 0, '*') == SPK_FILES[0][:-1] + SPK_FILES[1]
-        assert stpool('SPK_FILES', 1, '*') == \
-                         SPK_FILES[2][:-1] + SPK_FILES[3][:-1] + SPK_FILES[4]
-        with pytest.raises(KeyError):
-            stpool('SPK_FILES', 2, '*')
 
-        assert stpool.flag('SPK_FILES', 0, '*') == \
-                         [SPK_FILES[0][:-1] + SPK_FILES[1], True]
-        assert stpool.flag('SPK_FILES', 1, '*') == \
-                         [SPK_FILES[2][:-1] + SPK_FILES[3][:-1] + SPK_FILES[4], True]
-        assert not stpool.flag('SPK_FILES', 2, '*')[1]
+def test_expool_dtpool():
+    assert expool('BODY699_RADII')
+    assert not expool('BODY699_RADIIxxx')
+    assert dtpool_error('BODY699_RADII') == [3, 'N']
+    assert dtpool.flag('BODY699_RADII') == [True, 3, 'N']
+    assert dtpool.flag('BODY699_RADIIxxx')[0] == False
+    with pytest.raises(KeyError):
+        dtpool_error('BODY699_RADIIxxx')
 
-    def test_bodc2n_bodn2c_bodc2s_bods2c(self):
-        INTMAX = intmax()
-        #### bodc2n, bodn2c, bodc2s, bods2c
-        boddef('BIG!', -INTMAX)
+def test_gnpool():
+    assert set(gnpool('BODY699*RA*')) == {'BODY699_POLE_RA', 'BODY699_RADII'}
+    with pytest.raises(KeyError):
+        gnpool('BODY699*RAxxx*')
 
-        assert bodc2n.flag(699) == ['SATURN', True]
-        assert bodc2n_error(699) == 'SATURN'
-        assert bodc2n.flag(INTMAX)[1] == False
-        with pytest.raises(Exception):
-            bodc2n_error(INTMAX)
+    assert set(gnpool.flag('BODY699*RA*')[0]) == {'BODY699_POLE_RA', 'BODY699_RADII'}
+    assert gnpool.flag('BODY699*RA*')[1]
+    assert not gnpool.flag('BODY699*RAxxx*')[1]
 
-        assert bodn2c.flag('SATuRN ') == [699, True]
-        assert bodn2c_error('SATURN') == 699
-        assert bodn2c.flag('foobar')[1] == False
-        with pytest.raises(Exception):
-            bodn2c_error('foobar')
 
-        assert bodc2s(699) == 'SATURN'
-        assert bodc2s(INTMAX) == str(INTMAX)
+def test_stpool():
+    SPK_FILES = ['this_is_the_full_path_specification_*',
+                 'of_a_file_with_a_long_name',
+                 'this_is_the_full_path_specification_*',
+                 'of_a_second_file_with_a_very_long_*',
+                 'name']
+    pcpool('SPK_FILES', SPK_FILES)
 
-        assert bods2c.flag('SATuRN ') == [699, True]
-        assert bods2c_error('SATURN') == 699
-        assert bods2c.flag('foobar')[1] == False
-        with pytest.raises(Exception):
-            bods2c_error('foobar')
-        assert bods2c_error('  699 ') == 699
-        assert bods2c_error(str(INTMAX)) == INTMAX
+    assert stpool('SPK_FILES', 0, '*') == SPK_FILES[0][:-1] + SPK_FILES[1]
+    assert stpool('SPK_FILES', 1, '*') == \
+                     SPK_FILES[2][:-1] + SPK_FILES[3][:-1] + SPK_FILES[4]
+    with pytest.raises(KeyError):
+        stpool('SPK_FILES', 2, '*')
 
-        self.assertAllEqual(bltfrm(1).as_array(), range(1, 22), 0)
+    assert stpool.flag('SPK_FILES', 0, '*') == \
+                     [SPK_FILES[0][:-1] + SPK_FILES[1], True]
+    assert stpool.flag('SPK_FILES', 1, '*') == \
+                     [SPK_FILES[2][:-1] + SPK_FILES[3][:-1] + SPK_FILES[4], True]
+    assert not stpool.flag('SPK_FILES', 2, '*')[1]
 
-        #  self.assertAllEqual(kplfrm(1), range(1,22), 0)
-        boddef('BIG!', INTMAX)
 
-        assert bodc2n.flag(INTMAX) == ['BIG!', True]
-        assert bodc2n_error(INTMAX) == 'BIG!'
+def test_bodc2n_bodn2c_bodc2s_bods2c():
+    INTMAX = intmax()
+    #### bodc2n, bodn2c, bodc2s, bods2c
+    boddef('BIG!', -INTMAX)
 
-        assert bodn2c.flag('BiG! ') == [INTMAX, True]
-        assert bodn2c_error('BIG!') == INTMAX
+    assert bodc2n.flag(699) == ['SATURN', True]
+    assert bodc2n_error(699) == 'SATURN'
+    assert bodc2n.flag(INTMAX)[1] == False
+    with pytest.raises(Exception):
+        bodc2n_error(INTMAX)
 
-        assert bodc2s(INTMAX) == 'BIG!'
-        assert bods2c.flag('BiG! ') == [INTMAX, True]
-        assert bods2c_error('BIG!') == INTMAX
+    assert bodn2c.flag('SATuRN ') == [699, True]
+    assert bodn2c_error('SATURN') == 699
+    assert bodn2c.flag('foobar')[1] == False
+    with pytest.raises(Exception):
+        bodn2c_error('foobar')
 
-    def test_bodfnd(self):
-        INTMIN = intmin()
-        assert bodfnd(699, 'RADII')
-        assert not bodfnd(699, 'RADIIxxx')
-        assert not bodfnd(INTMIN, 'RADII')
+    assert bodc2s(699) == 'SATURN'
+    assert bodc2s(INTMAX) == str(INTMAX)
 
-    def test_bodvcd(self):
-        assert bodvcd(699, 'RADII')[0] == 60268.
-        assert bodvcd(699, 'RADII')[1] == 60268.
-        assert bodvcd(699, 'RADII')[2] == 54364.
-        with pytest.raises(KeyError):
-            bodvcd(699, 'RADIIxxx')
+    assert bods2c.flag('SATuRN ') == [699, True]
+    assert bods2c_error('SATURN') == 699
+    assert bods2c.flag('foobar')[1] == False
+    with pytest.raises(Exception):
+        bods2c_error('foobar')
+    assert bods2c_error('  699 ') == 699
+    assert bods2c_error(str(INTMAX)) == INTMAX
 
-    def test_bodvrd(self):
-        assert bodvrd('SATURN', 'RADII')[0] == 60268.
-        assert bodvrd('SATURN', 'RADII')[1] == 60268.
-        assert bodvrd('SATURN', 'RADII')[2] == 54364.
-        with pytest.raises(KeyError):
-            bodvrd('SATURN', 'RADIIxxx')
+    assert_all_equal(bltfrm(1).as_array(), range(1, 22), 0)
 
-    def test_bodvar(self):
-        assert bodvar(699, 'RADII')[0] == 60268.
-        assert bodvar(699, 'RADII')[1] == 60268.
-        assert bodvar(699, 'RADII')[2] == 54364.
-        with pytest.raises(KeyError):
-            bodvar(699, 'RADIIxxx')
+    #  assertAllEqual(kplfrm(1), range(1,22), 0)
+    boddef('BIG!', INTMAX)
 
-    def test_cidfrm(self):
-        INTMIN = intmin()
-        assert cidfrm.flag(699) == [10016, 'IAU_SATURN', True]
-        assert cidfrm_error(699) == [10016, 'IAU_SATURN']
-        assert cidfrm.flag(INTMIN)[2] == False
-        with pytest.raises(KeyError):
-            cidfrm_error(INTMIN)
+    assert bodc2n.flag(INTMAX) == ['BIG!', True]
+    assert bodc2n_error(INTMAX) == 'BIG!'
 
-    def test_ccifrm(self):
-        INTMIN = intmin()
-        assert cidfrm.flag(INTMIN)[2] == False
-        assert ccifrm.flag(2, 699) == [10016, 'IAU_SATURN', 699, True]
-        assert ccifrm_error(2, 699) == [10016, 'IAU_SATURN', 699]
-        assert ccifrm.flag(2, INTMIN)[3] == False
-        with pytest.raises(ValueError):
-            ccifrm_error(INTMIN, INTMIN)
+    assert bodn2c.flag('BiG! ') == [INTMAX, True]
+    assert bodn2c_error('BIG!') == INTMAX
 
-    def test_ckcov(self):
-        values = ckcov(PATH_ / '17257_17262ra.bc', -82000, False, 'INTERVAL', 1., 'SCLK')
-        npt.assert_array_equal(values.as_intervals(),
-                               [[304593554335.0, 304610188193.0],
-                                [304610195359.0, 304622337377.0],
-                                [304622354271.0, 304625376609.0]])
+    assert bodc2s(INTMAX) == 'BIG!'
+    assert bods2c.flag('BiG! ') == [INTMAX, True]
+    assert bods2c_error('BIG!') == INTMAX
 
-        values = ckcov.flag(PATH_ / '17257_17262ra.bc', 1, False, 'INTERVAL', 1., 'SCLK')
-        assert values.card == 0
 
-        with pytest.raises(KeyError):
-            ckcov_error(PATH_ / '17257_17262ra.bc', 1, False, 'INTERVAL', 1., 'SCLK')
+def test_bodfnd():
+    INTMIN = intmin()
+    assert bodfnd(699, 'RADII')
+    assert not bodfnd(699, 'RADIIxxx')
+    assert not bodfnd(INTMIN, 'RADII')
 
-        #### pckcov, pckfrm
-        with pytest.raises(IOError):
-            pckcov(PATH_ / 'pck00010.tpc', 10016)
 
-        frames = pckfrm(PATH_ / 'earth_000101_180317_171224.bpc')
-        limits = [-4.31358161e+04, 5.74516869e+08]
-        self.assertAllClose(pckcov(PATH_ / 'earth_000101_180317_171224.bpc', 3000).as_array(),
-                            limits)
+def test_bodvcd():
+    assert bodvcd(699, 'RADII')[0] == 60268.
+    assert bodvcd(699, 'RADII')[1] == 60268.
+    assert bodvcd(699, 'RADII')[2] == 54364.
+    with pytest.raises(KeyError):
+        bodvcd(699, 'RADIIxxx')
 
-    def test_ckgp_ckgpav(self):
-        sclk = 304593554335.
-        (array1a, sclk1, found1) = ckgp.flag(-82000, sclk, 1., 'J2000')
-        (array2a, array2b, sclk2, found2) = ckgpav.flag(-82000, sclk, 1., 'J2000')
 
-        assert found1
-        assert found2
+def test_bodvrd():
+    assert bodvrd('SATURN', 'RADII')[0] == 60268.
+    assert bodvrd('SATURN', 'RADII')[1] == 60268.
+    assert bodvrd('SATURN', 'RADII')[2] == 54364.
+    with pytest.raises(KeyError):
+        bodvrd('SATURN', 'RADIIxxx')
 
-        (array1a, sclk1,) = ckgp(-82000, sclk, 1., 'J2000')
-        (array2a, array2b, sclk2) = ckgpav(-82000, sclk, 1., 'J2000')
+def test_bodvar():
+    assert bodvar(699, 'RADII')[0] == 60268.
+    assert bodvar(699, 'RADII')[1] == 60268.
+    assert bodvar(699, 'RADII')[2] == 54364.
+    with pytest.raises(KeyError):
+        bodvar(699, 'RADIIxxx')
 
-        assert abs(sclk1 - sclk1) <= 1.
-        assert sclk1 == sclk2
-        self.assertAllEqual(array1a, array2a, 0.)
 
-        result2a = np.array([[-0.099802, -0.37245036, -0.92267019],
-                             [-0.03169184, -0.92563955, 0.37707699],
-                             [-0.99450248, 0.06687415, 0.08057704]])
+def test_cidfrm():
+    INTMIN = intmin()
+    assert cidfrm.flag(699) == [10016, 'IAU_SATURN', True]
+    assert cidfrm_error(699) == [10016, 'IAU_SATURN']
+    assert cidfrm.flag(INTMIN)[2] == False
+    with pytest.raises(KeyError):
+        cidfrm_error(INTMIN)
+
+
+def test_ccifrm():
+    INTMIN = intmin()
+    assert cidfrm.flag(INTMIN)[2] == False
+    assert ccifrm.flag(2, 699) == [10016, 'IAU_SATURN', 699, True]
+    assert ccifrm_error(2, 699) == [10016, 'IAU_SATURN', 699]
+    assert ccifrm.flag(2, INTMIN)[3] == False
+    with pytest.raises(ValueError):
+        ccifrm_error(INTMIN, INTMIN)
+
+
+def test_ckcov():
+    values = ckcov(PATH_ / '17257_17262ra.bc', -82000, False, 'INTERVAL', 1., 'SCLK')
+    npt.assert_array_equal(values.as_intervals(),
+                           [[304593554335.0, 304610188193.0],
+                            [304610195359.0, 304622337377.0],
+                            [304622354271.0, 304625376609.0]])
+
+    values = ckcov.flag(PATH_ / '17257_17262ra.bc', 1, False, 'INTERVAL', 1., 'SCLK')
+    assert values.card == 0
+
+    with pytest.raises(KeyError):
+        ckcov_error(PATH_ / '17257_17262ra.bc', 1, False, 'INTERVAL', 1., 'SCLK')
+
+    #### pckcov, pckfrm
+    with pytest.raises(IOError):
+        pckcov(PATH_ / 'pck00010.tpc', 10016)
+
+    frames = pckfrm(PATH_ / 'earth_000101_180317_171224.bpc')
+    limits = [-4.31358161e+04, 5.74516869e+08]
+    assert_all_close(pckcov(PATH_ / 'earth_000101_180317_171224.bpc', 3000).as_array(),
+                        limits)
+
+
+def test_ckgp_ckgpav():
+    sclk = 304593554335.
+    (array1a, sclk1, found1) = ckgp.flag(-82000, sclk, 1., 'J2000')
+    (array2a, array2b, sclk2, found2) = ckgpav.flag(-82000, sclk, 1., 'J2000')
+
+    assert found1
+    assert found2
+
+    (array1a, sclk1,) = ckgp(-82000, sclk, 1., 'J2000')
+    (array2a, array2b, sclk2) = ckgpav(-82000, sclk, 1., 'J2000')
+
+    assert abs(sclk1 - sclk1) <= 1.
+    assert sclk1 == sclk2
+    assert_all_equal(array1a, array2a, 0.)
+
+    result2a = np.array([[-0.099802, -0.37245036, -0.92267019],
+                         [-0.03169184, -0.92563955, 0.37707699],
+                         [-0.99450248, 0.06687415, 0.08057704]])
 
         result2b = np.array([3.46254953e-05, 5.05354838e-06, -1.12043171e-05])
 
-        self.assertAllEqual(array2a, result2a, 5.e-9)
-        self.assertAllEqual(array2b, result2b, 4.e-14)
+    assert_all_equal(array2a, result2a, 5.e-9)
+    assert_all_equal(array2b, result2b, 4.e-14)
 
-        # sclk is 0.
-        assert not ckgp.flag(-82000, 0., 1., 'J2000')[-1]
-        assert not ckgpav.flag(-82000, 0., 1., 'J2000')[-1]
+    # sclk is 0.
+    assert not ckgp.flag(-82000, 0., 1., 'J2000')[-1]
+    assert not ckgpav.flag(-82000, 0., 1., 'J2000')[-1]
 
-        with pytest.raises(IOError):
-            ckgp_error(-82000, 0., 1., 'J2000')
-        with pytest.raises(IOError):
-            ckgpav_error(-82000, 0., 1., 'J2000')
+    with pytest.raises(IOError):
+        ckgp_error(-82000, 0., 1., 'J2000')
+    with pytest.raises(IOError):
+        ckgpav_error(-82000, 0., 1., 'J2000')
 
-        # sclk is 0.
-        assert not ckgp.flag(-82000, 0., 1., 'J2000')[-1]
-        assert not ckgpav.flag(-82000, 0., 1., 'J2000')[-1]
+    # sclk is 0.
+    assert not ckgp.flag(-82000, 0., 1., 'J2000')[-1]
+    assert not ckgpav.flag(-82000, 0., 1., 'J2000')[-1]
 
-        with pytest.raises(IOError):
-            ckgp_error(-82000, 0., 1., 'J2000')
-        with pytest.raises(IOError):
-            ckgpav_error(-82000, 0., 1., 'J2000')
+    with pytest.raises(IOError):
+        ckgp_error(-82000, 0., 1., 'J2000')
+    with pytest.raises(IOError):
+        ckgpav_error(-82000, 0., 1., 'J2000')
 
-        sclk = sclk + 100. * np.arange(10)
-        (array1ax, sclk1x) = ckgp_vector(-82000, sclk, 1., 'J2000')
-        (array2ax, array2bx, sclk2x) = ckgpav_vector(-82000, sclk, 1., 'J2000')
+    sclk = sclk + 100. * np.arange(10)
+    (array1ax, sclk1x) = ckgp_vector(-82000, sclk, 1., 'J2000')
+    (array2ax, array2bx, sclk2x) = ckgpav_vector(-82000, sclk, 1., 'J2000')
 
-        assert array1ax.shape == (10, 3, 3)
-        assert array2ax.shape == (10, 3, 3)
-        assert array2bx.shape == (10, 3)
-        self.assertAllEqual(array1ax[0], array1a, 0)
-        self.assertAllEqual(array2ax[0], array2a, 0)
-        self.assertAllEqual(array2bx[0], array2b, 0)
+    assert array1ax.shape == (10, 3, 3)
+    assert array2ax.shape == (10, 3, 3)
+    assert array2bx.shape == (10, 3)
+    assert_all_equal(array1ax[0], array1a, 0)
+    assert_all_equal(array2ax[0], array2a, 0)
+    assert_all_equal(array2bx[0], array2b, 0)
 
-        sclk = sclk + 100. * np.arange(10)
-        (array1ax, sclk1x, found1x) = ckgp_vector.flag(-82000, sclk, 1., 'J2000')
-        (array2ax, array2bx, sclk2x, found2x) = ckgpav_vector.flag(-82000, sclk, 1., 'J2000')
+    sclk = sclk + 100. * np.arange(10)
+    (array1ax, sclk1x, found1x) = ckgp_vector.flag(-82000, sclk, 1., 'J2000')
+    (array2ax, array2bx, sclk2x, found2x) = ckgpav_vector.flag(-82000, sclk, 1., 'J2000')
 
-        assert array1ax.shape == (10, 3, 3)
-        assert array2ax.shape == (10, 3, 3)
-        assert array2bx.shape == (10, 3)
-        self.assertAllEqual(array1ax[0], array1a, 0)
-        self.assertAllEqual(array2ax[0], array2a, 0)
-        self.assertAllEqual(array2bx[0], array2b, 0)
-        assert np.all(found1x)
-        assert np.all(found2x)
+    assert array1ax.shape == (10, 3, 3)
+    assert array2ax.shape == (10, 3, 3)
+    assert array2bx.shape == (10, 3)
+    assert_all_equal(array1ax[0], array1a, 0)
+    assert_all_equal(array2ax[0], array2a, 0)
+    assert_all_equal(array2bx[0], array2b, 0)
+    assert np.all(found1x)
+    assert np.all(found2x)
 
-    def test_ckobj(self):
-        assert ckobj(PATH_ / '17257_17262ra.bc').as_array() == [-82000]
 
-    def test_cnmfrm(self):
-        assert cnmfrm('SATURN') == [10016, 'IAU_SATURN']
-        assert cnmfrm.flag('SATURN')[-1]
-        assert not cnmfrm.flag('foo')[-1]
-        with pytest.raises(KeyError):
-            cnmfrm_error('foo')
+def test_ckobj():
+    assert ckobj(PATH_ / '17257_17262ra.bc').as_array() == [-82000]
 
-    def test_dpgrdr_drdpgr(self):
-        self.assertAllEqual(dpgrdr('saturn', 1., 0., 0., 1., 0.), [[0, -1, 0],
-                                                                   [0, 0, 1],
-                                                                   [1, 0, 0]])
-        self.assertAllEqual(drdpgr('saturn', 1., 0., 0., 1., 0.),
-                            [[-0.84147098, 0., 0.54030231],
-                             [-0.54030231, 0., -0.84147098],
-                             [0., 1., 0.]], 5e-9)
-        assert dpgrdr_vector('saturn', 1., 0., [1, 2, 3, 4], 1., 0.).shape == \
-                         (4, 3, 3)
-        assert drdpgr_vector('saturn', 1., 0., 0., 1., [0.1, 0.02, 0.03, 0.04]).shape == (4, 3, 3)
 
-    def test_delte_t(self):
-        d = deltet(0., 'UTC')
-        self.assertAllEqual(d - 64.1839272847, 0., 4.e-11)
-        self.assertAllEqual(deltet_vector(np.arange(10), 'UTC'), 10 * [d], 4.e-9)
+def test_cnmfrm():
+    assert cnmfrm('SATURN') == [10016, 'IAU_SATURN']
+    assert cnmfrm.flag('SATURN')[-1]
+    assert not cnmfrm.flag('foo')[-1]
+    with pytest.raises(KeyError):
+        cnmfrm_error('foo')
 
-    def test_edterm(self):
-        results = edterm('UMBRAL', 'SUN', 'EARTH', 0., 'IAU_EARTH', 'LT+S',
-                         'MOON', 100)
-        assert len(results) == 3
-        assert np.shape(results[0]) == ()
-        assert results[1].shape == (3,)
-        assert results[2].shape == (100, 3)
 
-    def test_et2lst(self):
-        assert et2lst(0., 399, 0., 'PLANETOCENTRIC') == \
-                         [11, 55, 27, '11:55:27', '11:55:27 A.M.']
-        assert et2lst(0., 399, 43200., 'PLANETOCENTRIC') == \
-                         [23, 46, 9, '23:46:09', '11:46:09 P.M.']
+def test_dpgrdr_drdpgr():
+    assert_all_equal(dpgrdr('saturn', 1., 0., 0., 1., 0.), [[0, -1, 0],
+                                                            [0, 0, 1],
+                                                            [1, 0, 0]])
+    assert_all_equal(drdpgr('saturn', 1., 0., 0., 1., 0.),
+                     [[-0.84147098, 0., 0.54030231],
+                         [-0.54030231, 0., -0.84147098],
+                         [0., 1., 0.]], 5e-9)
+    assert dpgrdr_vector('saturn', 1., 0., [1, 2, 3, 4], 1., 0.).shape == \
+                     (4, 3, 3)
+    assert drdpgr_vector('saturn', 1., 0., 0., 1., [0.1, 0.02, 0.03, 0.04]).shape == (4, 3, 3)
 
-    def test_et2utc_utc2et_str2et_etcal(self):
-        utc = '2000-01-01T11:58:55.816'
-        assert et2utc(0., 'ISOC', 3) == utc
-        assert abs(utc2et(utc)) < 0.5e-3
-        assert abs(str2et(utc)) < 0.5e-3
-        assert etcal(0.) == '2000 JAN 01 12:00:00.000'
 
-    def test_frmnam_namfrm_frinfo(self):
-        INTMAX = intmax()
-        assert frmnam(10016) == 'IAU_SATURN'
-        assert frmnam.flag(10016) == 'IAU_SATURN'
-        assert frmnam.flag(INTMAX) == ''
-        with pytest.raises(KeyError):
-            frmnam_error(INTMAX)
+def test_deltet():
+    d = deltet(0., 'UTC')
+    assert_all_equal(d - 64.1839272847, 0., 4.e-11)
+    assert_all_equal(deltet_vector(np.arange(10), 'UTC'), 10 * [d], 4.e-9)
 
-        assert namfrm('IAU_SATURN') == 10016
-        assert namfrm.flag('IAU_SATURN') == 10016
-        assert namfrm.flag('xxxxx') == 0
-        with pytest.raises(KeyError):
-            namfrm_error('xxxxx')
 
-        assert frinfo(10016) == [699, 2, 699]
-        assert frinfo.flag(10016) == [699, 2, 699, True]
-        assert not frinfo.flag(INTMAX)[-1]
-        with pytest.raises(KeyError):
-            frinfo(INTMAX)
+def test_edterm():
+    results = edterm('UMBRAL', 'SUN', 'EARTH', 0., 'IAU_EARTH', 'LT+S',
+                     'MOON', 100)
+    assert len(results) == 3
+    assert np.shape(results[0]) == ()
+    assert results[1].shape == (3,)
+    assert results[2].shape == (100, 3)
 
-    def test_frmchg_sxform_pxform_xf2rav_pxfrm2_refchg(self):
-        sat0a = frmchg(10016, 1, 0.)
-        sat1a = frmchg(10016, 1, 86400.)
-        sat0b = sxform('IAU_SATURN', 'J2000', 0.)
-        sat1b = sxform('IAU_SATURN', 'J2000', 86400.)
-        sat0c = pxform('IAU_SATURN', 'J2000', 0.)
-        sat1c = pxform('IAU_SATURN', 'J2000', 86400.)
-        sat0d = pxfrm2('IAU_SATURN', 'J2000', 0., 0.)
-        sat1d = pxfrm2('IAU_SATURN', 'J2000', 86400., 86400.)
-        sat0e = refchg(10016, 1, 0.)
-        sat1e = refchg(10016, 1, 86400.)
 
-        self.assertAllEqual(sat0a[:3, :3], sat0b[:3, :3], 0)
-        self.assertAllEqual(sat0a[:3, :3], sat0c, 0)
-        self.assertAllEqual(sat0a[:3, :3], sat0d, 0)
-        self.assertAllEqual(sat0a[:3, :3], sat0e, 0)
-        self.assertAllEqual(sat0a[:3, :3], sat0a[3:, 3:], 0)  # true even for rotating frames
+def test_et2lst():
+    assert et2lst(0., 399, 0., 'PLANETOCENTRIC') == \
+                     [11, 55, 27, '11:55:27', '11:55:27 A.M.']
+    assert et2lst(0., 399, 43200., 'PLANETOCENTRIC') == \
+                     [23, 46, 9, '23:46:09', '11:46:09 P.M.']
 
-        self.assertAllEqual(sat1a[:3, :3], sat1b[:3, :3], 0)
-        self.assertAllEqual(sat1a[:3, :3], sat1c, 0)
-        self.assertAllEqual(sat1a[:3, :3], sat1d, 0)
-        self.assertAllEqual(sat1a[:3, :3], sat1e, 0)
-        self.assertAllEqual(sat1a[:3, :3], sat1a[3:, 3:], 0)  # true even for rotating frames
+
+def test_et2utc_utc2et_str2et_etcal():
+    utc = '2000-01-01T11:58:55.816'
+    assert et2utc(0., 'ISOC', 3) == utc
+    assert abs(utc2et(utc)) < 0.5e-3
+    assert abs(str2et(utc)) < 0.5e-3
+    assert etcal(0.) == '2000 JAN 01 12:00:00.000'
+
+
+def test_frmnam_namfrm_frinfo():
+    INTMAX = intmax()
+    assert frmnam(10016) == 'IAU_SATURN'
+    assert frmnam.flag(10016) == 'IAU_SATURN'
+    assert frmnam.flag(INTMAX) == ''
+    with pytest.raises(KeyError):
+        frmnam_error(INTMAX)
+
+    assert namfrm('IAU_SATURN') == 10016
+    assert namfrm.flag('IAU_SATURN') == 10016
+    assert namfrm.flag('xxxxx') == 0
+    with pytest.raises(KeyError):
+        namfrm_error('xxxxx')
+
+    assert frinfo(10016) == [699, 2, 699]
+    assert frinfo.flag(10016) == [699, 2, 699, True]
+    assert not frinfo.flag(INTMAX)[-1]
+    with pytest.raises(KeyError):
+        frinfo(INTMAX)
+
+
+def test_frmchg_sxform_pxform_xf2rav_pxfrm2_refchg():
+    sat0a = frmchg(10016, 1, 0.)
+    sat1a = frmchg(10016, 1, 86400.)
+    sat0b = sxform('IAU_SATURN', 'J2000', 0.)
+    sat1b = sxform('IAU_SATURN', 'J2000', 86400.)
+    sat0c = pxform('IAU_SATURN', 'J2000', 0.)
+    sat1c = pxform('IAU_SATURN', 'J2000', 86400.)
+    sat0d = pxfrm2('IAU_SATURN', 'J2000', 0., 0.)
+    sat1d = pxfrm2('IAU_SATURN', 'J2000', 86400., 86400.)
+    sat0e = refchg(10016, 1, 0.)
+    sat1e = refchg(10016, 1, 86400.)
+
+    assert_all_equal(sat0a[:3, :3], sat0b[:3, :3], 0)
+    assert_all_equal(sat0a[:3, :3], sat0c, 0)
+    assert_all_equal(sat0a[:3, :3], sat0d, 0)
+    assert_all_equal(sat0a[:3, :3], sat0e, 0)
+    assert_all_equal(sat0a[:3, :3], sat0a[3:, 3:], 0)  # true even for rotating frames
+
+    assert_all_equal(sat1a[:3, :3], sat1b[:3, :3], 0)
+    assert_all_equal(sat1a[:3, :3], sat1c, 0)
+    assert_all_equal(sat1a[:3, :3], sat1d, 0)
+    assert_all_equal(sat1a[:3, :3], sat1e, 0)
+    assert_all_equal(sat1a[:3, :3], sat1a[3:, 3:], 0)  # true even for rotating frames
 
         (mat0a, vec0a) = xf2rav(sat0a)
         (mat1a, vec1a) = xf2rav(sat1a)
         (mat0b, vec0b) = xf2rav(sat0b)
         (mat1b, vec1b) = xf2rav(sat1b)
 
-        self.assertAllEqual(sat0a[:3, :3], mat0a, 0)
-        self.assertAllEqual(sat1a[:3, :3], mat1a, 0)
-        self.assertAllEqual(sat0b[:3, :3], mat0b, 0)
-        self.assertAllEqual(sat1b[:3, :3], mat1b, 0)
+    assert_all_equal(sat0a[:3, :3], mat0a, 0)
+    assert_all_equal(sat1a[:3, :3], mat1a, 0)
+    assert_all_equal(sat0b[:3, :3], mat0b, 0)
+    assert_all_equal(sat1b[:3, :3], mat1b, 0)
 
-        # Make sure that non-rotating frames have the form we're expecting
-        non_rotate = frmchg(1, 2, 0.)  # J2000 and B1950 are both fixed
-        self.assertAllEqual(non_rotate[:3, :3], non_rotate[3:, 3:])
-        assert not np.any(non_rotate[:3, 3:])  # top left and bottom right are zero
-        assert not np.any(non_rotate[3:, :3])
-        non_rotate_matrix, non_rotate_vec = xf2rav(non_rotate)
-        self.assertAllEqual(non_rotate[:3, :3], non_rotate_matrix)
-        self.assertAllEqual(non_rotate_vec, [0., 0., 0.])
+    # Make sure that non-rotating frames have the form we're expecting
+    non_rotate = frmchg(1, 2, 0.)  # J2000 and B1950 are both fixed
+    assert_all_equal(non_rotate[:3, :3], non_rotate[3:, 3:])
+    assert not np.any(non_rotate[:3, 3:])  # top left and bottom right are zero
+    assert not np.any(non_rotate[3:, :3])
+    non_rotate_matrix, non_rotate_vec = xf2rav(non_rotate)
+    assert_all_equal(non_rotate[:3, :3], non_rotate_matrix)
+    assert_all_equal(non_rotate_vec, [0., 0., 0.])
 
-        self.assertAllEqual(vec0b, vec1b, 1.e-13)
+    assert_all_equal(vec0b, vec1b, 1.e-13)
 
-        sat01a = frmchg_vector(10016, 1, [0., 86400.])
-        sat01b = sxform_vector('IAU_SATURN', 'J2000', [0., 86400.])
-        sat01c = pxform_vector('IAU_SATURN', 'J2000', [0., 86400.])
-        sat01d = pxfrm2_vector('IAU_SATURN', 'J2000', [0., 86400.], [0., 86400.])
-        sat01e = refchg_vector(10016, 1, [0., 86400.])
+    sat01a = frmchg_vector(10016, 1, [0., 86400.])
+    sat01b = sxform_vector('IAU_SATURN', 'J2000', [0., 86400.])
+    sat01c = pxform_vector('IAU_SATURN', 'J2000', [0., 86400.])
+    sat01d = pxfrm2_vector('IAU_SATURN', 'J2000', [0., 86400.], [0., 86400.])
+    sat01e = refchg_vector(10016, 1, [0., 86400.])
 
-        self.assertAllEqual(sat01a, [sat0a, sat1a], 0)
-        self.assertAllEqual(sat01b, [sat0b, sat1b], 0)
-        self.assertAllEqual(sat01c, [sat0c, sat1c], 0)
-        self.assertAllEqual(sat01d, [sat0d, sat1d], 0)
-        self.assertAllEqual(sat01e, [sat0e, sat1e], 0)
+    assert_all_equal(sat01a, [sat0a, sat1a], 0)
+    assert_all_equal(sat01b, [sat0b, sat1b], 0)
+    assert_all_equal(sat01c, [sat0c, sat1c], 0)
+    assert_all_equal(sat01d, [sat0d, sat1d], 0)
+    assert_all_equal(sat01e, [sat0e, sat1e], 0)
 
-        (mat01b, vec01b) = xf2rav_vector(sat01b)
-        self.assertAllEqual(mat01b, [mat0b, mat1b], 0)
-        self.assertAllEqual(vec01b, [vec0b, vec1b], 0)
+    (mat01b, vec01b) = xf2rav_vector(sat01b)
+    assert_all_equal(mat01b, [mat0b, mat1b], 0)
+    assert_all_equal(vec01b, [vec0b, vec1b], 0)
 
-    def test_pgrrec_recpgr(self):
-        #### pgrrec, recpgr
-        self.assertAllEqual(pgrrec('MIMAS', 0, 0, 1, 1, 0.1), [2, 0, 0])
-        self.assertAllEqual(recpgr('MIMAS', [2, 0, 0], 1, 0.1), [0, 0, 1])
 
-        self.assertAllEqual(pgrrec_vector('MIMAS', [0, 0], 0, 1, 1, 0.1), 2 * [[2, 0, 0]])
-        self.assertAllEqual(recpgr_vector('MIMAS', [2, 0, 0], [1, 1], 0.1),
-                            [[0, 0], [0, 0], [1, 1]])
+def test_pgrrec_recpgr():
+    #### pgrrec, recpgr
+    assert_all_equal(pgrrec('MIMAS', 0, 0, 1, 1, 0.1), [2, 0, 0])
+    assert_all_equal(recpgr('MIMAS', [2, 0, 0], 1, 0.1), [0, 0, 1])
 
-    def test_lspcn(self):
-        Y2005 = 5 * 365.25 * 86400.
-        Y2006 = 6 * 365.25 * 86400.
-        self.assertAllEqual(lspcn('SATURN', Y2005, 'LT+S'), 5.23103124275, 1.e-11)
-        self.assertAllEqual(lspcn('SATURN', Y2006, 'LT+S'), 5.46639556423, 1.e-11)
-        self.assertAllEqual(lspcn_vector('SATURN', Y2006, 'LT+S'), 5.46639556423, 1.e-11)
-        self.assertAllEqual(lspcn_vector('SATURN', [Y2005, Y2006], 'LT+S'),
-                            [5.23103124275, 5.46639556423], 1.e-11)
+    assert_all_equal(pgrrec_vector('MIMAS', [0, 0], 0, 1, 1, 0.1), 2 * [[2, 0, 0]])
+    assert_all_equal(recpgr_vector('MIMAS', [2, 0, 0], [1, 1], 0.1),
+                     [[0, 0], [0, 0], [1, 1]])
 
-    def test_latsrf(self):  # no vector version
-        Y2005 = 5 * 365.25 * 86400.
-        Y2006 = 6 * 365.25 * 86400.
-        mimas = bodn2c('MIMAS')
-        (a, b, C) = bodvcd(mimas, 'RADII')
-        lonlats = np.array([[0, 0], [90, 0], [180, 0], [270, 0], [0, -90], [0, 90]]) * rpd()
-        results5 = latsrf('ELLIPSOID', 'MIMAS', Y2005, 'IAU_MIMAS', lonlats)
-        results6 = latsrf('ELLIPSOID', 'MIMAS', Y2006, 'IAU_MIMAS', lonlats)
 
-        target = [[a, 0, 0], [0, b, 0], [-a, 0, 0], [0, -b, 0], [0, 0, -C], [0, 0, C]]
-        self.assertAllEqual(results5, target, 4e-14)
-        self.assertAllEqual(results6, target, 4e-14)
+def test_lspcn():
+    Y2005 = 5 * 365.25 * 86400.
+    Y2006 = 6 * 365.25 * 86400.
+    assert_all_equal(lspcn('SATURN', Y2005, 'LT+S'), 5.23103124275, 1.e-11)
+    assert_all_equal(lspcn('SATURN', Y2006, 'LT+S'), 5.46639556423, 1.e-11)
+    assert_all_equal(lspcn_vector('SATURN', Y2006, 'LT+S'), 5.46639556423, 1.e-11)
+    assert_all_equal(lspcn_vector('SATURN', [Y2005, Y2006], 'LT+S'),
+                     [5.23103124275, 5.46639556423], 1.e-11)
 
-    def test_ltime(self, CASSINI_ET):
-        self.assertAllEqual(ltime(CASSINI_ET, -82, '->', 399),
-                            [556996483.4720103, 4843.472010222729], 1.e-7)
-        self.assertAllEqual(ltime(CASSINI_ET, -82, '<-', 399),
-                            [556986797.4373786, 4842.562621312754], 1.e-7)
-        self.assertAllEqual(ltime_vector(CASSINI_ET, -82, '<-', 399),
-                            [556986797.4373786, 4842.562621312754], 1.e-7)
-        self.assertAllEqual(ltime_vector(3 * [CASSINI_ET], -82, '<-', 399),
-                            [3 * [556986797.4373786], 3 * [4842.562621312754]], 1.e-7)
 
-    def test_spkcov_spkobj(self):
-        #### spkcov, spkobj
-        with pytest.raises(IOError):
-            spkcov('foo.bsp', -82)
+def test_latsrf():  # no vector version
+    Y2005 = 5 * 365.25 * 86400.
+    Y2006 = 6 * 365.25 * 86400.
+    mimas = bodn2c('MIMAS')
+    (a, b, C) = bodvcd(mimas, 'RADII')
+    lonlats = np.array([[0, 0], [90, 0], [180, 0], [270, 0], [0, -90], [0, 90]]) * rpd()
+    results5 = latsrf('ELLIPSOID', 'MIMAS', Y2005, 'IAU_MIMAS', lonlats)
+    results6 = latsrf('ELLIPSOID', 'MIMAS', Y2006, 'IAU_MIMAS', lonlats)
 
-        spkpath = PATH_ / '171106R_SCPSE_17224_17258.bsp'
-        with pytest.raises(KeyError):
-            spkcov(spkpath, 401)
+    target = [[a, 0, 0], [0, b, 0], [-a, 0, 0], [0, -b, 0], [0, 0, -C], [0, 0, C]]
+    assert_all_equal(results5, target, 4e-14)
+    assert_all_equal(results6, target, 4e-14)
 
-        limits = [5.55782400e+08, 5.58745200e+08]
-        self.assertAllEqual(spkcov(spkpath, -82).as_intervals(), [limits], 1.)
-        self.assertAllEqual(spkcov(spkpath, 699).as_intervals(), [limits], 1.)
 
-        self.assertAllEqual(spkcov.flag(spkpath, 699).as_intervals(), [limits], 1.)
-        self.assertAllEqual(spkcov.flag(spkpath, 401).as_intervals(), np.empty((0, 2)))
+def test_ltime(CASSINI_ET):
+    assert_all_equal(ltime(CASSINI_ET, -82, '->', 399),
+                     [556996483.4720103, 4843.472010222729], 1.e-7)
+    assert_all_equal(ltime(CASSINI_ET, -82, '<-', 399),
+                     [556986797.4373786, 4842.562621312754], 1.e-7)
+    assert_all_equal(ltime_vector(CASSINI_ET, -82, '<-', 399),
+                     [556986797.4373786, 4842.562621312754], 1.e-7)
+    assert_all_equal(ltime_vector(3 * [CASSINI_ET], -82, '<-', 399),
+                     [3 * [556986797.4373786], 3 * [4842.562621312754]], 1.e-7)
 
-        bodies = set([-82, 301, 399, 699] + list(range(1, 11)) +
-                     list(range(601, 613)) +
-                     list(range(615, 618)))
-        temp = spkobj(PATH_ / '171106R_SCPSE_17224_17258.bsp')
-        assert set(temp) == bodies
 
-    def test_illum_illumf_illumg_ilumin_phaseg(self, CASSINI_ET, CASSINI_ET2, eps):
-        trgepc = 556991636.744989
-        srfvec = [-898913.54085495, -158678.38639218, -344986.06074434]
-        phase = 2.3355683234002207
-        incdnc = 2.6877326371660395
-        emissn = 0.39969284462247634
-        visibl = True
-        lit = False
+def test_spkcov_spkobj():
+    #### spkcov, spkobj
+    with pytest.raises(IOError):
+        spkcov('foo.bsp', -82)
 
-        trgepc2 = 557078039.2141582
-        srfvec2 = [-197119.85363806, 61957.21359249, 113170.06834279]
-        phase2 = 3.0776373659048852
-        incdnc2 = 2.6248933305972493
-        emissn2 = 0.5795501233580607
-        visibl2 = True
-        lit2 = False
+    spkpath = PATH_ / '171106R_SCPSE_17224_17258.bsp'
+    with pytest.raises(KeyError):
+        spkcov(spkpath, 401)
 
-        self.assertAllEqual(illum('mimas', CASSINI_ET, 'lt+S', 'cassini',
+    limits = [5.55782400e+08, 5.58745200e+08]
+    assert_all_equal(spkcov(spkpath, -82).as_intervals(), [limits], 1.)
+    assert_all_equal(spkcov(spkpath, 699).as_intervals(), [limits], 1.)
+
+    assert_all_equal(spkcov.flag(spkpath, 699).as_intervals(), [limits], 1.)
+    assert_all_equal(spkcov.flag(spkpath, 401).as_intervals(), np.empty((0, 2)))
+
+    bodies = set([-82, 301, 399, 699] + list(range(1, 11)) +
+                 list(range(601, 613)) +
+                 list(range(615, 618)))
+    temp = spkobj(PATH_ / '171106R_SCPSE_17224_17258.bsp')
+    assert set(temp) == bodies
+
+
+def test_illum_illumf_illumg_ilumin_phaseg(CASSINI_ET, CASSINI_ET2, eps):
+    trgepc = 556991636.744989
+    srfvec = [-898913.54085495, -158678.38639218, -344986.06074434]
+    phase = 2.3355683234002207
+    incdnc = 2.6877326371660395
+    emissn = 0.39969284462247634
+    visibl = True
+    lit = False
+
+    trgepc2 = 557078039.2141582
+    srfvec2 = [-197119.85363806, 61957.21359249, 113170.06834279]
+    phase2 = 3.0776373659048852
+    incdnc2 = 2.6248933305972493
+    emissn2 = 0.5795501233580607
+    visibl2 = True
+    lit2 = False
+
+    assert_all_equal(illum('mimas', CASSINI_ET, 'lt+S', 'cassini',
+                           [200, 0, 0]),
+                     [phase, incdnc, emissn], eps)
+    assert_all_equal(illumf('ellipsoid', 'mimas', 'sun', CASSINI_ET,
+                               'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc, srfvec, phase, incdnc, emissn, visibl, lit], eps)
+    assert_all_equal(illumg('ellipsoid', 'mimas', 'sun', CASSINI_ET,
+                               'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc, srfvec, phase, incdnc, emissn], eps)
+    assert_all_equal(ilumin('ellipsoid', 'mimas', CASSINI_ET,
+                               'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc, srfvec, phase, incdnc, emissn], eps)
+
+    assert_all_equal(illum('mimas', CASSINI_ET2, 'lt+S', 'cassini',
+                           [200, 0, 0]),
+                     [phase2, incdnc2, emissn2], eps)
+    assert_all_equal(illumf('ellipsoid', 'mimas', 'sun', CASSINI_ET2,
+                               'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc2, srfvec2, phase2, incdnc2, emissn2, visibl2, lit2],
+                     eps)
+    assert_all_equal(illumg('ellipsoid', 'mimas', 'sun', CASSINI_ET2,
+                               'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc2, srfvec2, phase2, incdnc2, emissn2], eps)
+    assert_all_equal(ilumin('ellipsoid', 'mimas', CASSINI_ET2,
+                               'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc2, srfvec2, phase2, incdnc2, emissn2], eps)
+
+    assert_all_equal(illum_vector('mimas', CASSINI_ET, 'lt+S', 'cassini',
                                   [200, 0, 0]),
-                            [phase, incdnc, emissn], eps)
-        self.assertAllEqual(illumf('ellipsoid', 'mimas', 'sun', CASSINI_ET,
-                                   'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc, srfvec, phase, incdnc, emissn, visibl, lit], eps)
-        self.assertAllEqual(illumg('ellipsoid', 'mimas', 'sun', CASSINI_ET,
-                                   'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc, srfvec, phase, incdnc, emissn], eps)
-        self.assertAllEqual(ilumin('ellipsoid', 'mimas', CASSINI_ET,
-                                   'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc, srfvec, phase, incdnc, emissn], eps)
+                     [phase, incdnc, emissn], eps)
+    assert_all_equal(illumf_vector('ellipsoid', 'mimas', 'sun', CASSINI_ET,
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc, srfvec, phase, incdnc, emissn, visibl, lit], eps)
+    assert_all_equal(illumg_vector('ellipsoid', 'mimas', 'sun', CASSINI_ET,
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc, srfvec, phase, incdnc, emissn], eps)
+    assert_all_equal(ilumin_vector('ellipsoid', 'mimas', CASSINI_ET,
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [trgepc, srfvec, phase, incdnc, emissn], eps)
 
-        self.assertAllEqual(illum('mimas', CASSINI_ET2, 'lt+S', 'cassini',
+    assert_all_equal(illum_vector('mimas', [CASSINI_ET], 'lt+S', 'cassini',
                                   [200, 0, 0]),
-                            [phase2, incdnc2, emissn2], eps)
-        self.assertAllEqual(illumf('ellipsoid', 'mimas', 'sun', CASSINI_ET2,
-                                   'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc2, srfvec2, phase2, incdnc2, emissn2, visibl2, lit2],
-                            eps)
-        self.assertAllEqual(illumg('ellipsoid', 'mimas', 'sun', CASSINI_ET2,
-                                   'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc2, srfvec2, phase2, incdnc2, emissn2], eps)
-        self.assertAllEqual(ilumin('ellipsoid', 'mimas', CASSINI_ET2,
-                                   'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc2, srfvec2, phase2, incdnc2, emissn2], eps)
+                     [[phase], [incdnc], [emissn]], eps)
+    assert_all_equal(illumf_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET],
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [[trgepc], [srfvec], [phase], [incdnc], [emissn], [visibl],
+                         [lit]], eps)
+    assert_all_equal(illumg_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET],
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [[trgepc], [srfvec], [phase], [incdnc], [emissn]], eps)
+    assert_all_equal(ilumin_vector('ellipsoid', 'mimas', [CASSINI_ET],
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [[trgepc], [srfvec], [phase], [incdnc], [emissn]], eps)
 
-        self.assertAllEqual(illum_vector('mimas', CASSINI_ET, 'lt+S', 'cassini',
-                                         [200, 0, 0]),
-                            [phase, incdnc, emissn], eps)
-        self.assertAllEqual(illumf_vector('ellipsoid', 'mimas', 'sun', CASSINI_ET,
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc, srfvec, phase, incdnc, emissn, visibl, lit], eps)
-        self.assertAllEqual(illumg_vector('ellipsoid', 'mimas', 'sun', CASSINI_ET,
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc, srfvec, phase, incdnc, emissn], eps)
-        self.assertAllEqual(ilumin_vector('ellipsoid', 'mimas', CASSINI_ET,
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [trgepc, srfvec, phase, incdnc, emissn], eps)
+    assert_all_equal(
+        illum_vector('mimas', [CASSINI_ET, CASSINI_ET2], 'lt+S', 'cassini',
+                     [200, 0, 0]),
+        [[phase, phase2], [incdnc, incdnc2], [emissn, emissn2]], eps)
+    assert_all_equal(
+        illumf_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET, CASSINI_ET2],
+                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+        [[trgepc, trgepc2], [srfvec, srfvec2], [phase, phase2], [incdnc, incdnc2],
+         [emissn, emissn2], [visibl, visibl2], [lit, lit2]], eps)
+    assert_all_equal(
+        illumg_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET, CASSINI_ET2],
+                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+        [[trgepc, trgepc2], [srfvec, srfvec2], [phase, phase2], [incdnc, incdnc2],
+         [emissn, emissn2]], eps)
+    assert_all_equal(ilumin_vector('ellipsoid', 'mimas', [CASSINI_ET, CASSINI_ET2],
+                                      'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
+                     [[trgepc, trgepc2], [srfvec, srfvec2], [phase, phase2],
+                         [incdnc, incdnc2], [emissn, emissn2]], eps)
 
-        self.assertAllEqual(illum_vector('mimas', [CASSINI_ET], 'lt+S', 'cassini',
-                                         [200, 0, 0]),
-                            [[phase], [incdnc], [emissn]], eps)
-        self.assertAllEqual(illumf_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET],
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [[trgepc], [srfvec], [phase], [incdnc], [emissn], [visibl],
-                             [lit]], eps)
-        self.assertAllEqual(illumg_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET],
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [[trgepc], [srfvec], [phase], [incdnc], [emissn]], eps)
-        self.assertAllEqual(ilumin_vector('ellipsoid', 'mimas', [CASSINI_ET],
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [[trgepc], [srfvec], [phase], [incdnc], [emissn]], eps)
 
-        self.assertAllEqual(
-            illum_vector('mimas', [CASSINI_ET, CASSINI_ET2], 'lt+S', 'cassini',
-                         [200, 0, 0]),
-            [[phase, phase2], [incdnc, incdnc2], [emissn, emissn2]], eps)
-        self.assertAllEqual(
-            illumf_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET, CASSINI_ET2],
-                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-            [[trgepc, trgepc2], [srfvec, srfvec2], [phase, phase2], [incdnc, incdnc2],
-             [emissn, emissn2], [visibl, visibl2], [lit, lit2]], eps)
-        self.assertAllEqual(
-            illumg_vector('ellipsoid', 'mimas', 'sun', [CASSINI_ET, CASSINI_ET2],
-                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-            [[trgepc, trgepc2], [srfvec, srfvec2], [phase, phase2], [incdnc, incdnc2],
-             [emissn, emissn2]], eps)
-        self.assertAllEqual(ilumin_vector('ellipsoid', 'mimas', [CASSINI_ET, CASSINI_ET2],
-                                          'iau_mimas', 'lt+s', 'cassini', [200, 0, 0]),
-                            [[trgepc, trgepc2], [srfvec, srfvec2], [phase, phase2],
-                             [incdnc, incdnc2], [emissn, emissn2]], eps)
+def test_phaseq(CASSINI_ET, CASSINI_ET2, eps):
+    phase = 2.33564238748
+    phase2 = 3.07809474673
 
-    def test_phaseq(self, CASSINI_ET, CASSINI_ET2, eps):
-        phase = 2.33564238748
-        phase2 = 3.07809474673
+    assert_all_equal(phaseq(CASSINI_ET, 'mimas', 'sun', 'cassini', 'lt+s'),
+                     phase, eps)
+    assert_all_equal(phaseq(CASSINI_ET2, 'mimas', 'sun', 'cassini', 'lt+s'),
+                     phase2, eps)
 
-        self.assertAllEqual(phaseq(CASSINI_ET, 'mimas', 'sun', 'cassini', 'lt+s'),
-                            phase, eps)
-        self.assertAllEqual(phaseq(CASSINI_ET2, 'mimas', 'sun', 'cassini', 'lt+s'),
-                            phase2, eps)
+    assert_all_equal(phaseq_vector(CASSINI_ET, 'mimas', 'sun', 'cassini', 'lt+s'),
+                     phase, eps)
 
-        self.assertAllEqual(phaseq_vector(CASSINI_ET, 'mimas', 'sun', 'cassini', 'lt+s'),
-                            phase, eps)
+    assert_all_equal(
+        phaseq_vector([CASSINI_ET, CASSINI_ET2], 'mimas', 'sun', 'cassini', 'lt+s'),
+        [phase, phase2], eps)
 
-        self.assertAllEqual(
-            phaseq_vector([CASSINI_ET, CASSINI_ET2], 'mimas', 'sun', 'cassini', 'lt+s'),
-            [phase, phase2], eps)
 
-    def test_sce2c_sce2s_sce2t_scdecd_sct2e_scencd_scs2e_sctiks_scfmt_scpart(self, CASSINI_ET, CASSINI_ET2):
-        scdp = 3.04176877635e+11
-        scdp2 = 3.04198996178e+11
-        sclk = '1/1882414947.067'
-        sclk2 = '1/1882501347.210'
+def test_sce2c_sce2s_sce2t_scdecd_sct2e_scencd_scs2e_sctiks_scfmt_scpart(CASSINI_ET, CASSINI_ET2):
+    scdp = 3.04176877635e+11
+    scdp2 = 3.04198996178e+11
+    sclk = '1/1882414947.067'
+    sclk2 = '1/1882501347.210'
 
-        self.assertAllEqual(sce2c(-82, CASSINI_ET), scdp, 1.)
-        self.assertAllEqual(sce2c(-82, CASSINI_ET2), scdp2, 1.)
-        self.assertAllEqual(sce2s(-82, CASSINI_ET), sclk)
-        self.assertAllEqual(sce2s(-82, CASSINI_ET2), sclk2)
-        self.assertAllEqual(sce2t(-82, CASSINI_ET), scdp, 1.)
-        self.assertAllEqual(sce2t(-82, CASSINI_ET2), scdp2, 1.)
-        self.assertAllEqual(scdecd(-82, scdp), sclk)
-        self.assertAllEqual(scdecd(-82, scdp2), sclk2)
-        self.assertAllEqual(sct2e(-82, scdp), CASSINI_ET, 1.)
-        self.assertAllEqual(sct2e(-82, scdp2), CASSINI_ET2, 1.)
-        self.assertAllEqual(scencd(-82, sclk), scdp, 1.)
-        self.assertAllEqual(scencd(-82, sclk2), scdp2, 1.)
-        self.assertAllEqual(scs2e(-82, sclk), CASSINI_ET, 1.)
-        self.assertAllEqual(scs2e(-82, sclk2), CASSINI_ET2, 1.)
+    assert_all_equal(sce2c(-82, CASSINI_ET), scdp, 1.)
+    assert_all_equal(sce2c(-82, CASSINI_ET2), scdp2, 1.)
+    assert_all_equal(sce2s(-82, CASSINI_ET), sclk)
+    assert_all_equal(sce2s(-82, CASSINI_ET2), sclk2)
+    assert_all_equal(sce2t(-82, CASSINI_ET), scdp, 1.)
+    assert_all_equal(sce2t(-82, CASSINI_ET2), scdp2, 1.)
+    assert_all_equal(scdecd(-82, scdp), sclk)
+    assert_all_equal(scdecd(-82, scdp2), sclk2)
+    assert_all_equal(sct2e(-82, scdp), CASSINI_ET, 1.)
+    assert_all_equal(sct2e(-82, scdp2), CASSINI_ET2, 1.)
+    assert_all_equal(scencd(-82, sclk), scdp, 1.)
+    assert_all_equal(scencd(-82, sclk2), scdp2, 1.)
+    assert_all_equal(scs2e(-82, sclk), CASSINI_ET, 1.)
+    assert_all_equal(scs2e(-82, sclk2), CASSINI_ET2, 1.)
 
-        self.assertAllEqual(sctiks(-82, "1.000"), 256.)
-        self.assertAllEqual(sctiks(-82, "0.001"), 1.)
+    assert_all_equal(sctiks(-82, "1.000"), 256.)
+    assert_all_equal(sctiks(-82, "0.001"), 1.)
 
-        self.assertAllEqual(scfmt(-82, scdp), '1188190928.067')
-        self.assertAllEqual(scfmt(-82, scdp2), '1188277328.210')
+    assert_all_equal(scfmt(-82, scdp), '1188190928.067')
+    assert_all_equal(scfmt(-82, scdp2), '1188277328.210')
 
-        parts = [[1.77721349e+11], [1.09951163e+12]]
-        self.assertAllEqual(scpart(-82), parts, 30000.)
+    parts = [[1.77721349e+11], [1.09951163e+12]]
+    assert_all_equal(scpart(-82), parts, 30000.)
 
-        self.assertAllEqual(sce2c_vector(-82, CASSINI_ET), scdp, 1.)
-        self.assertAllEqual(sce2c_vector(-82, CASSINI_ET2), scdp2, 1.)
-        self.assertAllEqual(sce2t_vector(-82, CASSINI_ET), scdp, 1.)
-        self.assertAllEqual(sce2t_vector(-82, CASSINI_ET2), scdp2, 1.)
-        self.assertAllEqual(sct2e_vector(-82, scdp), CASSINI_ET, 1.)
-        self.assertAllEqual(sct2e_vector(-82, scdp2), CASSINI_ET2, 1.)
+    assert_all_equal(sce2c_vector(-82, CASSINI_ET), scdp, 1.)
+    assert_all_equal(sce2c_vector(-82, CASSINI_ET2), scdp2, 1.)
+    assert_all_equal(sce2t_vector(-82, CASSINI_ET), scdp, 1.)
+    assert_all_equal(sce2t_vector(-82, CASSINI_ET2), scdp2, 1.)
+    assert_all_equal(sct2e_vector(-82, scdp), CASSINI_ET, 1.)
+    assert_all_equal(sct2e_vector(-82, scdp2), CASSINI_ET2, 1.)
 
-        self.assertAllEqual(sce2c_vector(-82, [CASSINI_ET]), [scdp], 1.)
-        self.assertAllEqual(sce2c_vector(-82, [CASSINI_ET2]), [scdp2], 1.)
-        self.assertAllEqual(sce2t_vector(-82, [CASSINI_ET]), [scdp], 1.)
-        self.assertAllEqual(sce2t_vector(-82, [CASSINI_ET2]), [scdp2], 1.)
-        self.assertAllEqual(sct2e_vector(-82, [scdp]), [CASSINI_ET], 1.)
-        self.assertAllEqual(sct2e_vector(-82, [scdp2]), [CASSINI_ET2], 1.)
+    assert_all_equal(sce2c_vector(-82, [CASSINI_ET]), [scdp], 1.)
+    assert_all_equal(sce2c_vector(-82, [CASSINI_ET2]), [scdp2], 1.)
+    assert_all_equal(sce2t_vector(-82, [CASSINI_ET]), [scdp], 1.)
+    assert_all_equal(sce2t_vector(-82, [CASSINI_ET2]), [scdp2], 1.)
+    assert_all_equal(sct2e_vector(-82, [scdp]), [CASSINI_ET], 1.)
+    assert_all_equal(sct2e_vector(-82, [scdp2]), [CASSINI_ET2], 1.)
 
-        self.assertAllEqual(sce2c_vector(-82, [CASSINI_ET, CASSINI_ET2]), [scdp, scdp2], 1.)
-        self.assertAllEqual(sce2t_vector(-82, [CASSINI_ET, CASSINI_ET2]), [scdp, scdp2], 1.)
-        self.assertAllEqual(sct2e_vector(-82, [scdp, scdp2]), [CASSINI_ET, CASSINI_ET2], 1.)
+    assert_all_equal(sce2c_vector(-82, [CASSINI_ET, CASSINI_ET2]), [scdp, scdp2], 1.)
+    assert_all_equal(sce2t_vector(-82, [CASSINI_ET, CASSINI_ET2]), [scdp, scdp2], 1.)
+    assert_all_equal(sct2e_vector(-82, [scdp, scdp2]), [CASSINI_ET, CASSINI_ET2], 1.)
 
-    def test_spkssb_spkacs_spkapo_spkez_spkezr_spkpos(self, CASSINI_ET, CASSINI_ET2):
-        #### spkssb, spkacs, spkapo, spkez, spkezr, spkpos
-        xssb = [-9.35325266e+07, -1.38980049e+09, -5.69362184e+08, 1.00994262e+01,
-                5.57457613e+00, -1.32361199e+00]
-        xssb2 = [-9.28933887e+07, -1.38916427e+09, -5.69894015e+08, -8.14701094e-01,
-                 -1.90665286e+01, -8.26491731e+00]
 
-        ssb = spkssb(-82, CASSINI_ET, 'J2000')
-        ssb2 = spkssb(-82, CASSINI_ET2, 'J2000')
-        self.assertAllClose(spkssb(-82, CASSINI_ET, 'J2000'), xssb)
-        self.assertAllClose(spkssb(-82, CASSINI_ET2, 'J2000'), xssb2)
+def test_spkssb_spkacs_spkapo_spkez_spkezr_spkpos(CASSINI_ET, CASSINI_ET2):
+    xssb = [-9.35325266e+07, -1.38980049e+09, -5.69362184e+08, 1.00994262e+01,
+            5.57457613e+00, -1.32361199e+00]
+    xssb2 = [-9.28933887e+07, -1.38916427e+09, -5.69894015e+08, -8.14701094e-01,
+             -1.90665286e+01, -8.26491731e+00]
 
-        xstate = [-5.80013005e+04, 8.94350415e+05, -3.86487455e+05,
-                  -1.49765896e+01, -5.10106017e+00, 1.77874639e+00]
-        xstate2 = [2.09801346e+04, 2.11762463e+05, 1.01477978e+05,
-                   -3.43826105e+00, 1.42982547e+01, 8.91877142e+00]
-        xlt = 3.255625500957274
-        xdlt = -1.4972390244438447e-05
-        xlt2 = 0.7864001637489081
-        xdlt2 = 5.4624503604634114e-05
+    ssb = spkssb(-82, CASSINI_ET, 'J2000')
+    ssb2 = spkssb(-82, CASSINI_ET2, 'J2000')
+    assert_all_close(spkssb(-82, CASSINI_ET, 'J2000'), xssb)
+    assert_all_close(spkssb(-82, CASSINI_ET2, 'J2000'), xssb2)
 
-        (state, lt, dlt) = spkaps(601, CASSINI_ET, 'J2000', 'lt', ssb, [0, 0, 0])
-        (state2, lt2, dlt2) = spkaps(601, CASSINI_ET2, 'J2000', 'lt', ssb2, [0, 0, 0])
+    xstate = [-5.80013005e+04, 8.94350415e+05, -3.86487455e+05,
+              -1.49765896e+01, -5.10106017e+00, 1.77874639e+00]
+    xstate2 = [2.09801346e+04, 2.11762463e+05, 1.01477978e+05,
+               -3.43826105e+00, 1.42982547e+01, 8.91877142e+00]
+    xlt = 3.255625500957274
+    xdlt = -1.4972390244438447e-05
+    xlt2 = 0.7864001637489081
+    xdlt2 = 5.4624503604634114e-05
 
-        self.assertAllClose([state, lt, dlt], [xstate, xlt, xdlt])
-        self.assertAllClose([state2, lt2, dlt2], [xstate2, xlt2, xdlt2])
+    (state, lt, dlt) = spkaps(601, CASSINI_ET, 'J2000', 'lt', ssb, [0, 0, 0])
+    (state2, lt2, dlt2) = spkaps(601, CASSINI_ET2, 'J2000', 'lt', ssb2, [0, 0, 0])
 
-        self.assertAllEqual(spkacs(601, CASSINI_ET, 'J2000', 'lt', -82),
-                            [state, lt, dlt], 0)
-        self.assertAllEqual(spkacs(601, CASSINI_ET2, 'J2000', 'lt', -82),
-                            [state2, lt2, dlt2], 0)
+    assert_all_close([state, lt, dlt], [xstate, xlt, xdlt])
+    assert_all_close([state2, lt2, dlt2], [xstate2, xlt2, xdlt2])
 
-        self.assertAllEqual(spkapo(601, CASSINI_ET, 'J2000', ssb, 'lt'),
-                            [state[:3], lt], 0)
-        self.assertAllEqual(spkapo(601, CASSINI_ET2, 'J2000', ssb2, 'lt'),
-                            [state2[:3], lt2], 0)
+    assert_all_equal(spkacs(601, CASSINI_ET, 'J2000', 'lt', -82),
+                     [state, lt, dlt], 0)
+    assert_all_equal(spkacs(601, CASSINI_ET2, 'J2000', 'lt', -82),
+                     [state2, lt2, dlt2], 0)
 
-        self.assertAllEqual(spkez(601, CASSINI_ET, 'J2000', 'lt', -82),
-                            [state, lt], 0)
-        self.assertAllEqual(spkez(601, CASSINI_ET2, 'J2000', 'lt', -82),
-                            [state2, lt2], 0)
+    assert_all_equal(spkapo(601, CASSINI_ET, 'J2000', ssb, 'lt'),
+                     [state[:3], lt], 0)
+    assert_all_equal(spkapo(601, CASSINI_ET2, 'J2000', ssb2, 'lt'),
+                     [state2[:3], lt2], 0)
 
-        self.assertAllEqual(spkezp(601, CASSINI_ET, 'J2000', 'lt', -82),
-                            [state[:3], lt], 0)
-        self.assertAllEqual(spkezp(601, CASSINI_ET2, 'J2000', 'lt', -82),
-                            [state2[:3], lt2], 0)
+    assert_all_equal(spkez(601, CASSINI_ET, 'J2000', 'lt', -82),
+                     [state, lt], 0)
+    assert_all_equal(spkez(601, CASSINI_ET2, 'J2000', 'lt', -82),
+                     [state2, lt2], 0)
 
-        self.assertAllEqual(spkezr('mimas', CASSINI_ET, 'J2000', 'lt', 'cassini'),
-                            [state, lt], 0)
-        self.assertAllEqual(spkezr('mimas', CASSINI_ET2, 'J2000', 'lt', 'cassini'),
-                            [state2, lt2], 0)
+    assert_all_equal(spkezp(601, CASSINI_ET, 'J2000', 'lt', -82),
+                     [state[:3], lt], 0)
+    assert_all_equal(spkezp(601, CASSINI_ET2, 'J2000', 'lt', -82),
+                     [state2[:3], lt2], 0)
 
-        self.assertAllEqual(spkpos('mimas', CASSINI_ET, 'J2000', 'lt', 'cassini'),
-                            [state[:3], lt], 0)
-        self.assertAllEqual(spkpos('mimas', CASSINI_ET2, 'J2000', 'lt', 'cassini'),
-                            [state2[:3], lt2], 0)
+    assert_all_equal(spkezr('mimas', CASSINI_ET, 'J2000', 'lt', 'cassini'),
+                     [state, lt], 0)
+    assert_all_equal(spkezr('mimas', CASSINI_ET2, 'J2000', 'lt', 'cassini'),
+                     [state2, lt2], 0)
 
-        self.assertAllEqual(spkltc(601, CASSINI_ET, 'J2000', 'lt', ssb),
-                            [state, lt, dlt], 0)
-        self.assertAllEqual(spkltc(601, CASSINI_ET2, 'J2000', 'lt', ssb2),
-                            [state2, lt2, dlt2], 0)
+    assert_all_equal(spkpos('mimas', CASSINI_ET, 'J2000', 'lt', 'cassini'),
+                     [state[:3], lt], 0)
+    assert_all_equal(spkpos('mimas', CASSINI_ET2, 'J2000', 'lt', 'cassini'),
+                     [state2[:3], lt2], 0)
 
-    def test_spkez_spkgeo_spkgps(self, CASSINI_ET, CASSINI_ET2):
-        xstate = [-5.80171789e+04, 8.94351951e+05, -3.86485973e+05,
-                  -1.49767494e+01, -5.10452110e+00, 1.77892184e+00]
-        xstate2 = [2.09767900e+04, 2.11758713e+05, 1.01478492e+05,
-                   -3.43824167e+00, 1.42971900e+01, 8.91882636e+00]
-        xlt = 3.2556313860561055
-        xlt2 = 0.7863886730607871
+    assert_all_equal(spkltc(601, CASSINI_ET, 'J2000', 'lt', ssb),
+                     [state, lt, dlt], 0)
+    assert_all_equal(spkltc(601, CASSINI_ET2, 'J2000', 'lt', ssb2),
+                     [state2, lt2, dlt2], 0)
 
-        (state, lt) = spkez(601, CASSINI_ET, 'J2000', 'none', -82)
-        (state2, lt2) = spkez(601, CASSINI_ET2, 'J2000', 'none', -82)
 
-        self.assertAllClose(spkez(601, CASSINI_ET, 'J2000', 'none', -82),
-                            [xstate, xlt])
-        self.assertAllClose(spkez(601, CASSINI_ET2, 'J2000', 'none', -82),
-                            [xstate2, xlt2])
+def test_spkez_spkgeo_spkgps(CASSINI_ET, CASSINI_ET2):
+    xstate = [-5.80171789e+04, 8.94351951e+05, -3.86485973e+05,
+              -1.49767494e+01, -5.10452110e+00, 1.77892184e+00]
+    xstate2 = [2.09767900e+04, 2.11758713e+05, 1.01478492e+05,
+               -3.43824167e+00, 1.42971900e+01, 8.91882636e+00]
+    xlt = 3.2556313860561055
+    xlt2 = 0.7863886730607871
 
-        self.assertAllEqual(spkgeo(601, CASSINI_ET, 'J2000', -82),
-                            [state, lt], 0)
-        self.assertAllEqual(spkgeo(601, CASSINI_ET2, 'J2000', -82),
-                            [state2, lt2], 0)
+    (state, lt) = spkez(601, CASSINI_ET, 'J2000', 'none', -82)
+    (state2, lt2) = spkez(601, CASSINI_ET2, 'J2000', 'none', -82)
 
-        self.assertAllEqual(spkgps(601, CASSINI_ET, 'J2000', -82),
-                            [state[:3], lt], 0)
-        self.assertAllEqual(spkgps(601, CASSINI_ET2, 'J2000', -82),
-                            [state2[:3], lt2], 0)
+    assert_all_close(spkez(601, CASSINI_ET, 'J2000', 'none', -82),
+                        [xstate, xlt])
+    assert_all_close(spkez(601, CASSINI_ET2, 'J2000', 'none', -82),
+                        [xstate2, xlt2])
 
-    def test_srfc2s_srfcss_srfs2c_srfscc(self):
-        furnsh(PATH_ / 'phobos_surface.tm')  # Example from srfc2s_c.html
-        assert srfc2s(1, 401) == 'PHOBOS GASKELL Q512'
-        assert srfcss(1, 'phobos') == 'PHOBOS GASKELL Q512'
-        assert srfs2c('PHOBOS GASKELL Q512', 'phobos') == 1
-        assert srfscc('PHOBOS GASKELL Q512', 401) == 1
+    assert_all_equal(spkgeo(601, CASSINI_ET, 'J2000', -82),
+                     [state, lt], 0)
+    assert_all_equal(spkgeo(601, CASSINI_ET2, 'J2000', -82),
+                     [state2, lt2], 0)
 
-        with pytest.raises(KeyError):
-            srfc2s(2, 401)
-        with pytest.raises(KeyError):
-            srfc2s(1, 402)
-        with pytest.raises(KeyError):
-            srfcss(2, 'phobos')
-        with pytest.raises(KeyError):
-            srfcss(1, 'deimos')
-        with pytest.raises(KeyError):
-            srfs2c('whatever', 'phobos')
-        with pytest.raises(KeyError):
-            srfs2c('PHOBOS GASKELL Q512', 'deimos')
-        with pytest.raises(KeyError):
-            srfscc('whatever', 401)
-        with pytest.raises(KeyError):
-            srfscc('PHOBOS GASKELL Q512', 402)
+    assert_all_equal(spkgps(601, CASSINI_ET, 'J2000', -82),
+                     [state[:3], lt], 0)
+    assert_all_equal(spkgps(601, CASSINI_ET2, 'J2000', -82),
+                     [state2[:3], lt2], 0)
 
-        self.assertAllEqual(srfc2s.flag(1, 401), ['PHOBOS GASKELL Q512', True])
-        self.assertAllEqual(srfcss.flag(1, 'phobos'), ['PHOBOS GASKELL Q512', True])
-        self.assertAllEqual(srfs2c.flag('PHOBOS GASKELL Q512', 'phobos'), [1, True])
-        self.assertAllEqual(srfscc.flag('PHOBOS GASKELL Q512', 401), [1, True])
 
-        assert not srfc2s.flag(2, 401)[1]
-        assert not srfc2s.flag(1, 402)[1]
-        assert not srfcss.flag(2, 'phobos')[1]
-        assert not srfcss.flag(1, 'deimos')[1]
-        assert not srfs2c.flag('whatever', 'phobos')[1]
-        assert not srfs2c.flag('PHOBOS GASKELL Q512', 'deimos')[1]
-        assert not srfscc.flag('whatever', 401)[1]
-        assert not srfscc.flag('PHOBOS GASKELL Q512', 402)[1]
+def test_srfc2s_srfcss_srfs2c_srfscc():
+    furnsh(PATH_ / 'phobos_surface.tm')  # Example from srfc2s_c.html
+    assert srfc2s(1, 401) == 'PHOBOS GASKELL Q512'
+    assert srfcss(1, 'phobos') == 'PHOBOS GASKELL Q512'
+    assert srfs2c('PHOBOS GASKELL Q512', 'phobos') == 1
+    assert srfscc('PHOBOS GASKELL Q512', 401) == 1
 
-    def test_timdef(self):
-        assert timdef('get', 'calendar') == 'GREGORIAN'
+    with pytest.raises(KeyError):
+        srfc2s(2, 401)
+    with pytest.raises(KeyError):
+        srfc2s(1, 402)
+    with pytest.raises(KeyError):
+        srfcss(2, 'phobos')
+    with pytest.raises(KeyError):
+        srfcss(1, 'deimos')
+    with pytest.raises(KeyError):
+        srfs2c('whatever', 'phobos')
+    with pytest.raises(KeyError):
+        srfs2c('PHOBOS GASKELL Q512', 'deimos')
+    with pytest.raises(KeyError):
+        srfscc('whatever', 401)
+    with pytest.raises(KeyError):
+        srfscc('PHOBOS GASKELL Q512', 402)
+
+    assert_all_equal(srfc2s.flag(1, 401), ['PHOBOS GASKELL Q512', True])
+    assert_all_equal(srfcss.flag(1, 'phobos'), ['PHOBOS GASKELL Q512', True])
+    assert_all_equal(srfs2c.flag('PHOBOS GASKELL Q512', 'phobos'), [1, True])
+    assert_all_equal(srfscc.flag('PHOBOS GASKELL Q512', 401), [1, True])
+
+    assert not srfc2s.flag(2, 401)[1]
+    assert not srfc2s.flag(1, 402)[1]
+    assert not srfcss.flag(2, 'phobos')[1]
+    assert not srfcss.flag(1, 'deimos')[1]
+    assert not srfs2c.flag('whatever', 'phobos')[1]
+    assert not srfs2c.flag('PHOBOS GASKELL Q512', 'deimos')[1]
+    assert not srfscc.flag('whatever', 401)[1]
+    assert not srfscc.flag('PHOBOS GASKELL Q512', 402)[1]
+
+
+def test_timdef():
+    assert timdef('get', 'calendar') == 'GREGORIAN'
+    assert timdef('get', 'system') == 'UTC'
+    assert timdef('get', 'zone') == ''
+
+    assert timdef('set', 'calendar', 'mixed ') == 'mixed '
+    assert timdef('get', 'calendar') == 'MIXED'
+
+    assert timdef('set', 'system', 'utC') == 'utC'
+    assert timdef('get', 'system') == 'UTC'
+
+    assert timdef('set', 'zone', 'PDT') == 'PDT'
+    assert timdef('get', 'zone') == 'UTC-7'
+    timdef('set', 'zone', 'UTC-0')
+
+
+def test_tparse():
+    assert tparse('Tue Aug  6 11:10:57  1996') == -107398143.0
+    assert tparse('JANUary 1, 2000 12:00') == 0.
+
+    with pytest.raises(ValueError):
+        tparse('Tue Aug  6 11:10:57  1996g')
+    try:
+        tparse('Tue Aug  6 11:10:57  1996g')
+    except ValueError as e:
+        fullmsg = str(e)
+        msg = fullmsg.split(' -- ')[2]
+
+    assert tparse.flag('Tue Aug  6 11:10:57  1996') == [-107398143.0, '']
+    assert tparse.flag('JANUary 1, 2000 12:00') == [0., '']
+    assert tparse.flag('Tue Aug  6 11:10:57  1996g')[1] == msg
+
+
+def test_tpictr_timout():
+    time = 'Tue Aug 06 11:10:57  1996'
+    pictr = 'Wkd Mon DD HR:MN:SC  YYYY'
+    secs = -107398143.0
+    assert tparse(time) == secs
+    assert tpictr(time) == pictr
+    assert timout(secs + deltet(secs, 'UTC'), pictr) == time
+
+    time = 'JANUARY 01, 2000 12:00'
+    pictr = 'MONTH DD, YYYY HR:MN'
+    secs = 0.
+    assert tparse(time) == secs
+    assert tpictr(time) == pictr
+    assert timout(secs + deltet(secs, 'UTC'), pictr) == time
+
+    with pytest.raises(ValueError):
+        tpictr('Tue Aug  6 11:10:57  1996g')
+    try:
+        tpictr('Tue Aug  6 11:10:57  1996g')
+    except ValueError as e:
+        fullmsg = str(e)
+        msg = fullmsg.split(' -- ')[2]
+
+    assert_all_equal(tpictr.flag('Tue Aug  6 11:10:57  1996'),
+                     ['Wkd Mon  DD HR:MN:SC  YYYY', True, ''])
+    assert_all_equal(tpictr.flag('JANUary 1, 2000 12:00'),
+                     ['MONTH DD, YYYY HR:MN', True, ''])
+    assert_all_equal(tpictr.flag('Tue Aug  6 11:10:57  1996g')[1:], [False, msg])
+
+    assert timout(0., 'xxx') == 'xxx'
+
+
+def test_timdef():
+    timdef('zone', 'UTC-0')
+    assert timdef('get', 'zone') == 'UTC-0'
+    assert timdef('zone') == 'UTC-0'
+    assert timdef('zone', 'pdt') == 'pdt'
+    timdef('zone', 'UTC-0')
+
+    timdef('set', 'calendar', 'mixed')
+    assert timdef('get', 'calendar', '') == 'MIXED'
+    assert timdef('get', 'calendar') == 'MIXED'
+    assert timdef('calendar', '', '') == 'MIXED'
+    assert timdef('calendar', '') == 'MIXED'
+    assert timdef('calendar') == 'MIXED'
+
+    timdef('set', 'calendar', 'gregorian')
+    assert timdef('calendar') == 'GREGORIAN'
+    assert timdef('get', 'calendar') == 'GREGORIAN'
+
+    try:
+        timdef('set', 'system', 'tdb')
+        assert timdef('system') == 'TDB'
+        assert timdef('get', 'system') == 'TDB'
+        timdef('system', 'utc')
+        assert timdef('system') == 'UTC'
         assert timdef('get', 'system') == 'UTC'
-        assert timdef('get', 'zone') == ''
+    finally:
+        timdef('set', 'system', 'utc')  # DO NOT LEAVE TIME SYSTEM OTHER THAN UTC!!!
 
-        assert timdef('set', 'calendar', 'mixed ') == 'mixed '
-        assert timdef('get', 'calendar') == 'MIXED'
 
-        assert timdef('set', 'system', 'utC') == 'utC'
-        assert timdef('get', 'system') == 'UTC'
+def test_tsetyr():
+    tsetyr(2000)
+    assert tparse('Dec 31, 99') == 3155630400.0
+    tsetyr(1950)
+    assert tparse('Dec 31, 99') == -129600.0
 
-        assert timdef('set', 'zone', 'PDT') == 'PDT'
-        assert timdef('get', 'zone') == 'UTC-7'
-        timdef('set', 'zone', 'UTC-0')
 
-    def test_tparse(self):
-        assert tparse('Tue Aug  6 11:10:57  1996') == -107398143.0
-        assert tparse('JANUary 1, 2000 12:00') == 0.
-
-        with pytest.raises(ValueError):
-            tparse('Tue Aug  6 11:10:57  1996g')
-        try:
-            tparse('Tue Aug  6 11:10:57  1996g')
-        except ValueError as e:
-            fullmsg = str(e)
-            msg = fullmsg.split(' -- ')[2]
-
-        assert tparse.flag('Tue Aug  6 11:10:57  1996') == [-107398143.0, '']
-        assert tparse.flag('JANUary 1, 2000 12:00') == [0., '']
-        assert tparse.flag('Tue Aug  6 11:10:57  1996g')[1] == msg
-
-    def test_tpictr_timout(self):
-        time = 'Tue Aug 06 11:10:57  1996'
-        pictr = 'Wkd Mon DD HR:MN:SC  YYYY'
-        secs = -107398143.0
-        assert tparse(time) == secs
-        assert tpictr(time) == pictr
-        assert timout(secs + deltet(secs, 'UTC'), pictr) == time
-
-        time = 'JANUARY 01, 2000 12:00'
-        pictr = 'MONTH DD, YYYY HR:MN'
-        secs = 0.
-        assert tparse(time) == secs
-        assert tpictr(time) == pictr
-        assert timout(secs + deltet(secs, 'UTC'), pictr) == time
-
-        with pytest.raises(ValueError):
-            tpictr('Tue Aug  6 11:10:57  1996g')
-        try:
-            tpictr('Tue Aug  6 11:10:57  1996g')
-        except ValueError as e:
-            fullmsg = str(e)
-            msg = fullmsg.split(' -- ')[2]
-
-        self.assertAllEqual(tpictr.flag('Tue Aug  6 11:10:57  1996'),
-                            ['Wkd Mon  DD HR:MN:SC  YYYY', True, ''])
-        self.assertAllEqual(tpictr.flag('JANUary 1, 2000 12:00'),
-                            ['MONTH DD, YYYY HR:MN', True, ''])
-        self.assertAllEqual(tpictr.flag('Tue Aug  6 11:10:57  1996g')[1:], [False, msg])
-
-        assert timout(0., 'xxx') == 'xxx'
-
-    def test_timdef(self):
-        timdef('zone', 'UTC-0')
-        assert timdef('get', 'zone') == 'UTC-0'
-        assert timdef('zone') == 'UTC-0'
-        assert timdef('zone', 'pdt') == 'pdt'
-        timdef('zone', 'UTC-0')
-
-        timdef('set', 'calendar', 'mixed')
-        assert timdef('get', 'calendar', '') == 'MIXED'
-        assert timdef('get', 'calendar') == 'MIXED'
-        assert timdef('calendar', '', '') == 'MIXED'
-        assert timdef('calendar', '') == 'MIXED'
-        assert timdef('calendar') == 'MIXED'
-
-        timdef('set', 'calendar', 'gregorian')
-        assert timdef('calendar') == 'GREGORIAN'
-        assert timdef('get', 'calendar') == 'GREGORIAN'
-
-        try:
-            timdef('set', 'system', 'tdb')
-            assert timdef('system') == 'TDB'
-            assert timdef('get', 'system') == 'TDB'
-            timdef('system', 'utc')
-            assert timdef('system') == 'UTC'
-            assert timdef('get', 'system') == 'UTC'
-        finally:
-            timdef('set', 'system', 'utc')  # DO NOT LEAVE TIME SYSTEM OTHER THAN UTC!!!
-
-    def test_tsetyr(self):
-        tsetyr(2000)
-        assert tparse('Dec 31, 99') == 3155630400.0
-        tsetyr(1950)
-        assert tparse('Dec 31, 99') == -129600.0
-
-    def test_unitim(self):
-        self.assertAllClose(unitim(0., 'TAI', 'TDB'), 32.183927274)
-        self.assertAllClose(unitim(0., 'TAI', 'JED'), 2451545.00037)
+def test_unitim():
+    assert_all_close(unitim(0., 'TAI', 'TDB'), 32.183927274)
+    assert_all_close(unitim(0., 'TAI', 'JED'), 2451545.00037)
 


### PR DESCRIPTION
1.  Got rid of class in test_kernels
2.  Attempting to re-write test_errors forced me to re-examine error handling.
   a. Got rid of special handling of cspyce.sigerr().  It just fails, and the normal fail handling happens.
   b. cspice.sigerr() used to pop the chkin stack.  It no longer does this because doing that was a hack.  The functions in
        cspyce1.py are now responsible for dealing with checkin/checkout.
   c. A lot of the tests in test_error() presumed that sigerr popped the stack.  It no longer does that.
3. While I was in cspyce1.py, I got rid of all the .format statements.