### PR TITLE
Run tests on 3.12.  This found a couple of small bugs.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
       fail-fast: false
     steps:
       - name: Checkout

--- a/cspyce/typemap_test.py
+++ b/cspyce/typemap_test.py
@@ -652,7 +652,7 @@ class Test_INOUT_STRINGS_SizeFromArg:
 
     def test_okay_to_pass_empty_list(self):
         result = ts.sort_strings(())
-        assert result is ()
+        assert result == ()
 
     def test_requires_one_dimensional_array(self):
         argument = np.array([["a", "b", "c", "d"], ["w", "x", "y", "z"]])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 requests
 numpy
+setuptools

--- a/unittests/test_p_r.py
+++ b/unittests/test_p_r.py
@@ -327,7 +327,7 @@ def test_prompt(tmp_path):
     script_file = tmp_path / "script.py"
     script = f"""
         import sys
-        sys.path.insert(0, "{path}")  # Make sure we get the correct cspyce
+        sys.path.insert(0, r"{path}")  # Make sure we get the correct cspyce
         import cspyce as cs
         text = cs.prompt("{prompt}")
         print(text, end='', file=sys.stderr)


### PR DESCRIPTION
3.12 doesn't like "x is ()"
3.12 doesn't include setuptools.  Must be added by requirement
3.12 caught that on windows, we were handling \ incorrectly.