### PR TITLE
Use import_array1 instead of import_array

### DIFF
--- a/swig/cspyce0.i
+++ b/swig/cspyce0.i
@@ -142,7 +142,7 @@ void reset_messages(void);
 %fragment("NumPy_Fragments");
 
 %init %{
-        import_array(); /* For numpy interface */
+        import_array1(0); /* For numpy interface */
         erract_c("SET", 256, "RETURN");
         errdev_c("SET", 256, "NULL");   /* Suppresses default error messages */
         initialize_typemap_globals();

--- a/swig/typemap_samples.i
+++ b/swig/typemap_samples.i
@@ -16,7 +16,7 @@
 %fragment("NumPy_Fragments");
 
 %init %{
-    import_array(); /* For numpy interface */
+    import_array1(0); /* For numpy interface */
     erract_c("SET", 256, "RETURN");
     errdev_c("SET", 256, "NULL");   /* Suppresses default error messages */
     initialize_typemap_globals();


### PR DESCRIPTION
Fixes #181 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NumPy initialization implementation in SWIG configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->