### PR TITLE
Fix MacOS CI: replace PyInt_FromLong with PyLong_FromLong for SWIG 4.5.0

### DIFF
--- a/swig/cspyce_typemaps.i
+++ b/swig/cspyce_typemaps.i
@@ -1759,9 +1759,9 @@ TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE)
 * Now define these typemaps for every numeric type
 *******************************************************/
 
-TYPEMAP_ARGOUT(SpiceInt,      NPY_INT,  PyInt_FromLong)
-TYPEMAP_ARGOUT(SpiceInt,      NPY_INT,  PyInt_FromLong)
-TYPEMAP_ARGOUT(SpiceBoolean,  NPY_INT,  PyInt_FromLong)
+TYPEMAP_ARGOUT(SpiceInt,      NPY_INT,  PyLong_FromLong)
+TYPEMAP_ARGOUT(SpiceInt,      NPY_INT,  PyLong_FromLong)
+TYPEMAP_ARGOUT(SpiceBoolean,  NPY_INT,  PyLong_FromLong)
 TYPEMAP_ARGOUT(SpiceDouble,   NPY_DOUBLE, PyFloat_FromDouble)
 
 #undef TYPEMAP_ARGOUT
@@ -3222,7 +3222,7 @@ TYPEMAP_SPICE_CELL(SpiceCellChar,    SPICE_CHR)
 %enddef
 
 TYPEMAP_ARGOUT(SpiceBoolean, PyBool_FromLong(value$argnum))
-TYPEMAP_ARGOUT(SpiceInt,     PyInt_FromLong(value$argnum))
+TYPEMAP_ARGOUT(SpiceInt,     PyLong_FromLong(value$argnum))
 TYPEMAP_ARGOUT(SpiceDouble,  PyFloat_FromDouble(value$argnum))
 TYPEMAP_ARGOUT(SpiceChar,    PyUnicode_FromStringAndSize(&value$argnum, 1))
 TYPEMAP_ARGOUT(PyObject*,    (value$argnum))
@@ -3272,7 +3272,7 @@ TYPEMAP_ARGOUT(PyObject*,    (value$argnum))
     (SpiceInt RETURN_INT) {
 
     TEST_FOR_EXCEPTION;
-    $result = SWIG_AppendOutput($result, PyInt_FromLong((long) $1));
+    $result = SWIG_AppendOutput($result, PyLong_FromLong((long) $1));
 }
 
 %typemap(out)


### PR DESCRIPTION
## What broke

The MacOS CI jobs started failing at the **Build extensions** step in the scheduled runs on Aug 9 and Aug 16. All six MacOS jobs failed; Ubuntu and Windows stayed green.

The cause is **not** a compiler change. Comparing the last passing run to the first failing one, the toolchain is identical:

| | Aug 2 (pass) | Aug 16 (fail) |
|---|---|---|
| Compiler | Apple clang 21.0.0 (clang-2100.1.1.101), Xcode 26.6 | same |
| Homebrew SWIG | 4.4.1 | **4.5.0** |

SWIG 4.5.0 removed the Python 2 compatibility block from `Lib/python/pyhead.swg`, including:

```c
#define PyInt_FromLong(x) PyLong_FromLong(x)
```

`swig/cspyce_typemaps.i` relied on that shim in five places, so the generated wrappers stopped compiling:

```
swig/cspyce0_wrap.c:17175:53: error: call to undeclared function 'PyInt_FromLong';
    ISO C99 and later do not support implicit function declarations
swig/cspyce0_wrap.c:17175:53: error: incompatible integer to pointer conversion
    passing 'int' to parameter of type 'PyObject *'
```

MacOS is the only platform affected because it is the only one that runs `brew install swig` fresh on each build. Ubuntu and Windows use an older preinstalled swig that still ships the shim.

## The fix

Replace `PyInt_FromLong` with `PyLong_FromLong` (5 occurrences in `swig/cspyce_typemaps.i`). The removed macro expanded to exactly `PyLong_FromLong`, so this is a semantic no-op that works with every SWIG version.

## Verification

SWIG 4.5.0 was built from source locally to test against the exact version that broke CI:

- **Before fix, SWIG 4.5.0** — reproduced: 175 errors, all tracing to the single missing macro. Compiled with no error limit, so nothing was hidden behind clang's 20-error cap; there is no second 4.5.0 incompatibility.
- **After fix, SWIG 4.5.0** — 0 errors, full build, 875 tests pass.
- **After fix, SWIG 4.2.0** (older, comparable to the Ubuntu/Windows runners) — 0 errors, 875 tests pass. Backward compatible.

## Note

`publish-to-pypi.yml` and `publish-to-test-pypi.yml` also run unpinned `brew install swig`, so the next release would have hit this as well. This source fix covers them; no workflow change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VcVudZjDqbQbX33dMHaz6j


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Python 3 by correcting integer and boolean output conversions.
  * Ensured array scalar values and direct integer results are returned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->